### PR TITLE
Support multiple mods in one jar

### DIFF
--- a/src/main/java/net/coderbot/patchwork/Patchwork.java
+++ b/src/main/java/net/coderbot/patchwork/Patchwork.java
@@ -129,8 +129,7 @@ public class Patchwork {
 		List<Map.Entry<String, EventBusSubscriber>> eventBusSubscribers =
 				new ArrayList<>(); // basename -> EventBusSubscriber
 
-		AtomicReference<String> modName = new AtomicReference<>();
-		AtomicReference<String> modId = new AtomicReference<>();
+		HashMap<String, String> modInfo = new HashMap<>();
 
 		Files.walkFileTree(fs.getPath("/"), new SimpleFileVisitor<Path>() {
 			@Override
@@ -153,9 +152,9 @@ public class Patchwork {
 					Consumer<String> modConsumer = classModId -> {
 						System.out.println(
 								"Class " + baseName + " has @Mod annotation: " + classModId);
-
-						modName.set(baseName);
-						modId.set(classModId);
+						modInfo.put(classModId, baseName);
+						// modName.set(baseName);
+						// modId.set(classModId);
 					};
 
 					AnnotationProcessor scanner = new AnnotationProcessor(node, modConsumer);
@@ -275,31 +274,6 @@ public class Patchwork {
 			}
 		});
 
-		ClassWriter initializerWriter = new ClassWriter(0);
-
-		// TODO: register instance event registrars
-
-		String initializerName = "patchwork_generated" + modName.get() + "Initializer";
-		ForgeInitializerGenerator.generate(modName.get(),
-				initializerName,
-				modId.get(),
-				staticEventRegistrars,
-				instanceEventRegistrars,
-				eventBusSubscribers,
-				generatedObjectHolderEntries,
-				initializerWriter);
-
-		outputConsumer.accept("/" + initializerName, initializerWriter.toByteArray());
-
-		outputConsumer.close();
-
-		if(shouldClose) {
-			fs.close();
-		}
-
-		uri = new URI("jar:" + output.toUri().toString());
-		fs = FileSystems.newFileSystem(uri, Collections.emptyMap());
-
 		Path manifestPath = fs.getPath("/META-INF/mods.toml");
 
 		FileConfig toml = FileConfig.of(manifestPath);
@@ -311,16 +285,42 @@ public class Patchwork {
 
 		ModManifest manifest = ModManifest.parse(map);
 
-		// System.out.println("Parsed: " + manifest);
-
-		Gson gson = new GsonBuilder().setPrettyPrinting().create();
+		// TODO: register instance event registrars
 		List<JsonObject> mods = ModManifestConverter.convertToFabric(manifest);
-		JsonObject fabric = mods.get(0);
 
 		JsonObject entrypoints = new JsonObject();
 		JsonArray entrypoint = new JsonArray();
+		mods.forEach(m -> {
+			String id = m.getAsJsonPrimitive("id").getAsString();
+			ClassWriter initializerWriter = new ClassWriter(0);
+			String initializerName = "patchwork_generated" + modInfo.get(id) + "Initializer";
+			ForgeInitializerGenerator.generate(modInfo.get(id),
+					initializerName,
+					id,
+					staticEventRegistrars,
+					instanceEventRegistrars,
+					eventBusSubscribers,
+					generatedObjectHolderEntries,
+					initializerWriter);
+			entrypoint.add(initializerName.replace('/', '.'));
+			outputConsumer.accept("/" + initializerName, initializerWriter.toByteArray());
+		});
 
-		entrypoint.add(initializerName.replace('/', '.'));
+		outputConsumer.close();
+
+		if(shouldClose) {
+			fs.close();
+		}
+
+		uri = new URI("jar:" + output.toUri().toString());
+		fs = FileSystems.newFileSystem(uri, Collections.emptyMap());
+
+		// System.out.println("Parsed: " + manifest);
+
+		Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+		JsonObject fabric = mods.get(0);
+
 		entrypoints.add("patchwork", entrypoint);
 
 		fabric.add("entrypoints", entrypoints);
@@ -328,11 +328,12 @@ public class Patchwork {
 		mods.forEach((m) -> {
 			if(!m.equals(mods.get(0))) {
 				JsonObject file = new JsonObject();
-				file.addProperty("file", "META-INF/jars/" + m.getAsJsonPrimitive("id").getAsString() + ".jar");
+				file.addProperty("file",
+						"META-INF/jars/" + m.getAsJsonPrimitive("id").getAsString() + ".jar");
 				jarsArray.add(file);
 			}
 		});
-		fabric.add("jars",jarsArray);
+		fabric.add("jars", jarsArray);
 		String json = gson.toJson(fabric);
 
 		Path fabricModJson = fs.getPath("/fabric.mod.json");
@@ -344,25 +345,33 @@ public class Patchwork {
 
 		Files.write(fabricModJson, json.getBytes(StandardCharsets.UTF_8));
 
-		//System.out.println(json);
+		// System.out.println(json);
 		try {
 			Files.createDirectory(fs.getPath("/META-INF/jars/"));
-		} catch (IOException ignored) {}
-		for (JsonObject entry : mods) {
+		} catch(IOException ignored) {
+		}
+		for(JsonObject entry : mods) {
 			String modid = entry.getAsJsonPrimitive("id").getAsString();
-			if (entry != mods.get(0)) {
-				//generate the jar
-				Path subJarPath = Paths.get("temp/" + entry.getAsJsonPrimitive("id").getAsString() + ".jar");
-				OutputConsumerPath tempJarConsumer = new OutputConsumerPath.Builder
-						(subJarPath).build();
+			if(entry != mods.get(0)) {
+				// generate the jar
+				Path subJarPath =
+						Paths.get("temp/" + modid + ".jar");
+				OutputConsumerPath tempJarConsumer =
+						new OutputConsumerPath.Builder(subJarPath).build();
 
 				tempJarConsumer.close();
-				FileSystem subFs = FileSystems.newFileSystem(new URI("jar:" + subJarPath.toUri().toString()), Collections.emptyMap());
+				FileSystem subFs = FileSystems.newFileSystem(
+						new URI("jar:" + subJarPath.toUri().toString()), Collections.emptyMap());
 				Path modJsonPath = subFs.getPath("/fabric.mod.json");
-				Files.write(modJsonPath, entry.toString().getBytes(), StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE);
+				Files.write(modJsonPath,
+						entry.toString().getBytes(),
+						StandardOpenOption.TRUNCATE_EXISTING,
+						StandardOpenOption.CREATE);
 				subFs.close();
-				Files.write(fs.getPath("/META-INF/jars/" + modid + ".jar"), Files.readAllBytes(subJarPath), StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE);
-				//System.out.println(entry.getAsJsonPrimitive("id").getAsString());
+				Files.write(fs.getPath("/META-INF/jars/" + modid + ".jar"),
+						Files.readAllBytes(subJarPath),
+						StandardOpenOption.TRUNCATE_EXISTING,
+						StandardOpenOption.CREATE);
 			}
 		}
 

--- a/src/main/java/net/coderbot/patchwork/manifest/converter/ModManifestConverter.java
+++ b/src/main/java/net/coderbot/patchwork/manifest/converter/ModManifestConverter.java
@@ -4,6 +4,7 @@ import net.coderbot.patchwork.manifest.forge.ModManifest;
 import net.coderbot.patchwork.manifest.forge.ModManifestDependency;
 import net.coderbot.patchwork.manifest.forge.ModManifestEntry;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -12,31 +13,38 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 public class ModManifestConverter {
-	public static JsonObject convertToFabric(ModManifest manifest) {
-		if(manifest.getMods().size() != 1) {
-			// TODO: multiple mod manifests
-			throw new UnsupportedOperationException(
-					"Cannot process Forge mod manifests with multiple mods yet");
+	/**
+	 * Generates a list of JsonObjects based on all of the mods in the manifest.
+	 * Index 0 will contain all dependencies, etc. The rest should be saved into empty jars to show all the mods in things like ModMenu.
+	 * @param manifest
+	 * @return
+	 */
+	public static List<JsonObject> convertToFabric(ModManifest manifest) {
+		ArrayList<JsonObject> modJsons = new ArrayList<>();
+		//Populate mods
+		for(ModManifestEntry entry : manifest.getMods()) {
+			JsonObject json = convertToFabric(manifest, entry);
+			if(modJsons.size() == 0) {
+				//Add init stuff, etc here.
+
+			}
+			modJsons.add(json);
 		}
-
-		ModManifestEntry mod = manifest.getMods().get(0);
-		List<ModManifestDependency> dependencies =
-				manifest.getDependencyMapping().get(mod.getModId());
-
-		if(dependencies == null) {
-			dependencies = new ArrayList<>();
-		}
-
-		return convertToFabric(manifest, mod, dependencies);
+		return modJsons;
 	}
 
+	/**
+	 * Generates a basic fabric.mod.json.
+	 * Does not include dependencies, entrypoints--including patchwork's!--, or mixins.
+	 * These should all be handled somewhere else.
+	 * @param manifest
+	 * @param mod
+	 * @return A basic fabric.mod.json
+	 */
+
 	public static JsonObject convertToFabric(ModManifest manifest,
-			ModManifestEntry mod,
-			List<ModManifestDependency> dependencies) {
+			ModManifestEntry mod) {
 		// Build the JSON
-
-		// TODO: Dependencies, mixins, entrypoints
-
 		JsonObject json = new JsonObject();
 
 		json.addProperty("schemaVersion", 1);
@@ -59,13 +67,6 @@ public class ModManifestConverter {
 		}
 
 		logo.ifPresent(icon -> json.addProperty("icon", icon));
-
-		dependencies.removeIf(entry -> entry.getModId().equals("forge"));
-
-		if(dependencies.size() != 0) {
-			// TODO: throw new UnsupportedOperationException("Cannot write dependencies yet!");
-		}
-
 		return json;
 	}
 

--- a/src/main/java/net/coderbot/patchwork/manifest/converter/ModManifestConverter.java
+++ b/src/main/java/net/coderbot/patchwork/manifest/converter/ModManifestConverter.java
@@ -15,18 +15,18 @@ import com.google.gson.JsonObject;
 public class ModManifestConverter {
 	/**
 	 * Generates a list of JsonObjects based on all of the mods in the manifest.
-	 * Index 0 will contain all dependencies, etc. The rest should be saved into empty jars to show all the mods in things like ModMenu.
+	 * Index 0 will contain all dependencies, etc. The rest should be saved into empty jars to show
+	 * all the mods in things like ModMenu.
 	 * @param manifest
 	 * @return
 	 */
 	public static List<JsonObject> convertToFabric(ModManifest manifest) {
 		ArrayList<JsonObject> modJsons = new ArrayList<>();
-		//Populate mods
+		// Populate mods
 		for(ModManifestEntry entry : manifest.getMods()) {
 			JsonObject json = convertToFabric(manifest, entry);
 			if(modJsons.size() == 0) {
-				//Add init stuff, etc here.
-
+				// Add init stuff, etc here.
 			}
 			modJsons.add(json);
 		}
@@ -42,8 +42,7 @@ public class ModManifestConverter {
 	 * @return A basic fabric.mod.json
 	 */
 
-	public static JsonObject convertToFabric(ModManifest manifest,
-			ModManifestEntry mod) {
+	public static JsonObject convertToFabric(ModManifest manifest, ModManifestEntry mod) {
 		// Build the JSON
 		JsonObject json = new JsonObject();
 


### PR DESCRIPTION
This PR adds support for loading multiple `@Mod` classes in a single jar, along with actually showing mods besides the first in ModMenu. The second part does not work in development environments because loader doesn't load jar-in-jar mods for some reason.

Fabric does not support having multiple mods in one manifest. To get around this, Patchwork generates a dummy mod jar with a converted manifest for each mod besides the first one (the 'parent'). These dummy mods do not contain initailizers, mixins, or any classes. Instead, all of this logic is done only in the parent.
This PR will be followed up by one to Runtime that adds a test mod workspace.