### PR TITLE
Parse mod access transformers

### DIFF
--- a/src/main/java/com/patchworkmc/mapping/remapper/ManifestRemapper.java
+++ b/src/main/java/com/patchworkmc/mapping/remapper/ManifestRemapper.java
@@ -10,12 +10,8 @@ public class ManifestRemapper implements Remapper, AutoCloseable {
 	private TinyRemapper tiny;
 
 	public ManifestRemapper(IMappingProvider mappings) {
-		// TODO: this is a copy-paste of the old tinyremapper that was used in my original AT fork.
-		// Some of these flags might not be needed.
 		this.tiny = TinyRemapper.newRemapper()
 			.withMappings(mappings)
-			.rebuildSourceFilenames(true)
-			.ignoreFieldDesc(true)
 			.build();
 		this.asmRemapper = tiny.getRemapper();
 	}

--- a/src/main/java/com/patchworkmc/mapping/remapper/ManifestRemapper.java
+++ b/src/main/java/com/patchworkmc/mapping/remapper/ManifestRemapper.java
@@ -1,0 +1,47 @@
+package com.patchworkmc.mapping.remapper;
+
+import net.fabricmc.tinyremapper.IMappingProvider;
+import net.fabricmc.tinyremapper.TinyRemapper;
+
+import com.patchworkmc.manifest.api.Remapper;
+
+public class ManifestRemapper implements Remapper, AutoCloseable {
+	private org.objectweb.asm.commons.Remapper asmRemapper;
+	private TinyRemapper tiny;
+
+	public ManifestRemapper(IMappingProvider mappings) {
+		// TODO: this is a copy-paste of the old tinyremapper that was used in my original AT fork.
+		// Some of these flags might not be needed.
+		this.tiny = TinyRemapper.newRemapper()
+			.withMappings(mappings)
+			.rebuildSourceFilenames(true)
+			.ignoreFieldDesc(true)
+			.build();
+		this.asmRemapper = tiny.getRemapper();
+	}
+
+	@Override
+	public String remapMemberDescription(String descriptor) {
+		return asmRemapper.mapDesc(descriptor);
+	}
+
+	@Override
+	public String remapFieldName(String owner, String name, String descriptor) {
+		return asmRemapper.mapFieldName(owner, name, descriptor);
+	}
+
+	@Override
+	public String remapMethodName(String owner, String name, String descriptor) {
+		return asmRemapper.mapMethodName(owner, name, descriptor);
+	}
+
+	@Override
+	public String remapClassName(String name) {
+		return asmRemapper.map(name);
+	}
+
+	@Override
+	public void close() {
+		tiny.finish();
+	}
+}


### PR DESCRIPTION
The first of the AT pr saga, this parses and remaps access transformers, as well as refactors the metadata parsing (but not conversion) to before patching the mod jar in order to let us see the dependencies, access transformers, etc. while we patch.