### PR TITLE
Try to make both ways of running Patchwork less of a duplicated mess

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,8 @@ run {
 jar {
     manifest {
         attributes(
+				'Implementation-Title': 'Patchwork Patcher',
+				'Implementation-Version': archiveVersion,
                 'Main-Class': 'com.patchworkmc.PatchworkUI'
         )
     }

--- a/src/main/java/com/patchworkmc/Patchwork.java
+++ b/src/main/java/com/patchworkmc/Patchwork.java
@@ -71,30 +71,30 @@ public class Patchwork {
 			throw new IllegalArgumentException("Must have at least one IMappingProvider!");
 		}
 		NaiveRemapper naiveRemapper = new NaiveRemapper(mappings[0]);
+		long startTime = System.currentTimeMillis();
 		try(Stream<Path> inputFiles = Files.walk(inputDir).filter(file -> file.toString().endsWith(".jar"))) {
-			inputFiles.forEach(jarPath -> {
+			inputFiles.peek(jarPath -> {
 				try {
 					transformMod(dataDir, jarPath, outputDir, mappings[0], naiveRemapper);
-				} catch (IOException | URISyntaxException | ManifestParseException e) {
+				} catch (Exception e) {
 					e.printStackTrace();
 				}
-			});
-
-			for (int i = 0; i < mappings.length; i++) {
-				if(i == 0) continue;
-				IMappingProvider extraProvider = mappings[i];
-				int currentIteration = i;
-
-				inputFiles.forEach(jarPath -> {
+			}).forEach(jarPath -> {
+				for (int i = 0; i < mappings.length; i++) {
+					if(i == 0) continue;
+					IMappingProvider extraProvider = mappings[i];
+					int currentIteration = i;
 					String mod = jarPath.getFileName().toString().split("\\.jar")[0];
 					try {
 						remap(extraProvider, jarPath, outputDir.resolve(mod + "-dev-" + currentIteration + ".jar"));
 					} catch (IOException e) {
 						e.printStackTrace();
 					}
-				});
-			}
+				}
+			});
 		}
+		long endTime = System.currentTimeMillis();
+		System.out.println("Patched mods in " + (endTime - startTime) + "ms");
 	}
 
 	private void transformMod(Path dataDir, Path jarPath, Path outputRoot, IMappingProvider mappings, NaiveRemapper naiveRemapper)

--- a/src/main/java/com/patchworkmc/Patchwork.java
+++ b/src/main/java/com/patchworkmc/Patchwork.java
@@ -52,7 +52,7 @@ public class Patchwork {
 	public static final Logger LOGGER;
 	private static String version = "1.14.4";
 
-	private static byte[] patchworkGreyscaleIcon;
+	private byte[] patchworkGreyscaleIcon;
 
 	private Path inputDir, outputDir, dataDir, tempDir;
 	private IMappingProvider primaryMappings;
@@ -67,12 +67,6 @@ public class Patchwork {
 		//		 component sub loggers (see Logger#sub)
 		LOGGER = new Logger("Patchwork");
 		LOGGER.setWriter(new StreamWriter(true, System.out, System.err), LogLevel.TRACE);
-
-		try {
-			patchworkGreyscaleIcon = Files.readAllBytes(Paths.get(Patchwork.class.getResource("/patchwork-icon-greyscale.png").getPath()));
-		} catch (IOException ex) {
-			LOGGER.thrown(LogLevel.FATAL, ex);
-		}
 	}
 
 	public Patchwork(Path inputDir, Path outputDir, Path dataDir, Path tempDir, IMappingProvider primaryMappings, List<IMappingProvider> devMappings) {
@@ -82,6 +76,12 @@ public class Patchwork {
 		this.tempDir = tempDir;
 		this.primaryMappings = primaryMappings;
 		this.devMappings = devMappings;
+
+		try {
+			this.patchworkGreyscaleIcon = Files.readAllBytes(Paths.get(Patchwork.class.getResource("/patchwork-icon-greyscale.png").getPath()));
+		} catch (IOException ex) {
+			LOGGER.thrown(LogLevel.FATAL, ex);
+		}
 
 		this.naiveRemapper = new NaiveRemapper(primaryMappings);
 		this.manifestRemapper = new ManifestRemapper(primaryMappings);

--- a/src/main/java/com/patchworkmc/Patchwork.java
+++ b/src/main/java/com/patchworkmc/Patchwork.java
@@ -69,7 +69,7 @@ public class Patchwork {
 		LOGGER.setWriter(new StreamWriter(true, System.out, System.err), LogLevel.TRACE);
 
 		try {
-			patchworkGreyscaleIcon = Files.readAllBytes(new File(Patchwork.class.getResource("/patchwork-icon-greyscale.png").getPath()).toPath());
+			patchworkGreyscaleIcon = Files.readAllBytes(Paths.get(Patchwork.class.getResource("/patchwork-icon-greyscale.png").getPath()));
 		} catch (IOException ex) {
 			LOGGER.thrown(LogLevel.FATAL, ex);
 		}

--- a/src/main/java/com/patchworkmc/Patchwork.java
+++ b/src/main/java/com/patchworkmc/Patchwork.java
@@ -93,7 +93,7 @@ public class Patchwork {
 
 	public int patchAndFinish() throws IOException {
 		if (this.closed) {
-			throw new IllegalStateException("Cannot being patching: Already patched all mods!");
+			throw new IllegalStateException("Cannot begin patching: Already patched all mods!");
 		}
 		AtomicInteger count = new AtomicInteger();
 

--- a/src/main/java/com/patchworkmc/Patchwork.java
+++ b/src/main/java/com/patchworkmc/Patchwork.java
@@ -71,7 +71,6 @@ public class Patchwork {
 			throw new IllegalArgumentException("Must have at least one IMappingProvider!");
 		}
 		NaiveRemapper naiveRemapper = new NaiveRemapper(mappings[0]);
-		long startTime = System.currentTimeMillis();
 		try(Stream<Path> inputFiles = Files.walk(inputDir).filter(file -> file.toString().endsWith(".jar"))) {
 			inputFiles.peek(jarPath -> {
 				try {
@@ -93,8 +92,6 @@ public class Patchwork {
 				}
 			});
 		}
-		long endTime = System.currentTimeMillis();
-		System.out.println("Patched mods in " + (endTime - startTime) + "ms");
 	}
 
 	private void transformMod(Path dataDir, Path jarPath, Path outputRoot, IMappingProvider mappings, NaiveRemapper naiveRemapper)

--- a/src/main/java/com/patchworkmc/PatchworkUI.java
+++ b/src/main/java/com/patchworkmc/PatchworkUI.java
@@ -73,7 +73,6 @@ import com.patchworkmc.mapping.TinyWriter;
 import com.patchworkmc.mapping.Tsrg;
 import com.patchworkmc.mapping.TsrgClass;
 import com.patchworkmc.mapping.TsrgMappings;
-import com.patchworkmc.mapping.remapper.NaiveRemapper;
 
 public class PatchworkUI {
 	private static final String[] SUPPORTED_VERSIONS = {"1.14.4"};
@@ -562,14 +561,16 @@ public class PatchworkUI {
 
 		File inputFolder = new File(modsFolder.getText());
 		Path outputFolder = new File(PatchworkUI.outputFolder.getText()).toPath();
-		int[] patched = {0};
+		Patchwork patchwork;
+
 		if (generateDevJar.isSelected()) {
-			new Patchwork(inputFolder.toPath(), outputFolder, rootPath.resolve("data/"), rootPath.resolve("/temp"), bridged, yarnMappings[0]);
+			patchwork = new Patchwork(inputFolder.toPath(), outputFolder, rootPath.resolve("data/"), rootPath.resolve("/temp"), bridged, yarnMappings[0]);
 		} else {
-			new Patchwork(inputFolder.toPath(), outputFolder, rootPath.resolve("data/"), rootPath.resolve("/temp"), bridged);
+			patchwork = new Patchwork(inputFolder.toPath(), outputFolder, rootPath.resolve("data/"), rootPath.resolve("/temp"), bridged);
 		}
 
-		LOGGER.info("Successfully patched " + patched[0] + " mod(s)!");
+		int patched = patchwork.patchAndFinish();
+		LOGGER.info("Successfully patched " + patched + " mod(s)!");
 	}
 
 	private static void downloadYarn(YarnBuild yarnBuild, File parent) throws IOException {

--- a/src/main/java/com/patchworkmc/PatchworkUI.java
+++ b/src/main/java/com/patchworkmc/PatchworkUI.java
@@ -564,30 +564,7 @@ public class PatchworkUI {
 		File inputFolder = new File(modsFolder.getText());
 		Path outputFolder = new File(PatchworkUI.outputFolder.getText()).toPath();
 		int[] patched = {0};
-
-		Files.walk(inputFolder.toPath()).forEach(path -> {
-			if (!path.toString().endsWith(".jar")) {
-				return;
-			}
-
-			String modName = path.getFileName().toString().replaceAll(".jar", "");
-			LOGGER.info("=== Patching " + path.toString() + " ===");
-
-			try {
-				Patchwork.transformMod(rootPath, path, outputFolder, modName, bridged, naiveRemapper);
-
-				if (yarnBuild != null) {
-					LOGGER.info("Remapping " + modName + " (intermediary -> yarn)");
-					Patchwork.remap(yarnMappings[0], outputFolder.resolve(modName + ".jar"), outputFolder.resolve(modName + "-dev.jar"), rootPath.resolve("data/" + version + "-client+intermediary.jar"));
-				}
-
-				patched[0]++;
-			} catch (Throwable t) {
-				LOGGER.error("Transformation failed, skipping current mod!");
-
-				LOGGER.thrown(LogLevel.ERROR, t);
-			}
-		});
+		new Patchwork(inputFolder.toPath(), outputFolder, rootPath.resolve("data/"), rootPath.resolve("/temp"), bridged, yarnMappings[0]);
 		LOGGER.info("Successfully patched " + patched[0] + " mod(s)!");
 	}
 

--- a/src/main/java/com/patchworkmc/PatchworkUI.java
+++ b/src/main/java/com/patchworkmc/PatchworkUI.java
@@ -558,13 +558,17 @@ public class PatchworkUI {
 			}
 		}
 
-		NaiveRemapper naiveRemapper = new NaiveRemapper(bridged);
 		LOGGER.info("Preparation Complete!\n");
 
 		File inputFolder = new File(modsFolder.getText());
 		Path outputFolder = new File(PatchworkUI.outputFolder.getText()).toPath();
 		int[] patched = {0};
-		new Patchwork(inputFolder.toPath(), outputFolder, rootPath.resolve("data/"), rootPath.resolve("/temp"), bridged, yarnMappings[0]);
+		if (generateDevJar.isSelected()) {
+			new Patchwork(inputFolder.toPath(), outputFolder, rootPath.resolve("data/"), rootPath.resolve("/temp"), bridged, yarnMappings[0]);
+		} else {
+			new Patchwork(inputFolder.toPath(), outputFolder, rootPath.resolve("data/"), rootPath.resolve("/temp"), bridged);
+		}
+
 		LOGGER.info("Successfully patched " + patched[0] + " mod(s)!");
 	}
 

--- a/src/main/java/com/patchworkmc/PatchworkUI.java
+++ b/src/main/java/com/patchworkmc/PatchworkUI.java
@@ -559,14 +559,15 @@ public class PatchworkUI {
 
 		LOGGER.info("Preparation Complete!\n");
 
-		File inputFolder = new File(modsFolder.getText());
+		Path inputFolder = new File(modsFolder.getText()).toPath();
 		Path outputFolder = new File(PatchworkUI.outputFolder.getText()).toPath();
+		Path tempFolder = Files.createTempDirectory(rootPath, "temp");
 		Patchwork patchwork;
 
 		if (generateDevJar.isSelected()) {
-			patchwork = new Patchwork(inputFolder.toPath(), outputFolder, rootPath.resolve("data/"), rootPath.resolve("/temp"), bridged, yarnMappings[0]);
+			patchwork = new Patchwork(inputFolder, outputFolder, rootPath.resolve("data/"), tempFolder, bridged, yarnMappings[0]);
 		} else {
-			patchwork = new Patchwork(inputFolder.toPath(), outputFolder, rootPath.resolve("data/"), rootPath.resolve("/temp"), bridged);
+			patchwork = new Patchwork(inputFolder, outputFolder, rootPath.resolve("data/"), tempFolder, bridged);
 		}
 
 		int patched = patchwork.patchAndFinish();

--- a/src/main/java/com/patchworkmc/PatchworkUI.java
+++ b/src/main/java/com/patchworkmc/PatchworkUI.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.Permission;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -562,13 +563,9 @@ public class PatchworkUI {
 		Path inputFolder = new File(modsFolder.getText()).toPath();
 		Path outputFolder = new File(PatchworkUI.outputFolder.getText()).toPath();
 		Path tempFolder = Files.createTempDirectory(rootPath, "temp");
-		Patchwork patchwork;
+		List<IMappingProvider> devMappings = generateDevJar.isSelected() ? Collections.singletonList(yarnMappings[0]) : Collections.emptyList();
 
-		if (generateDevJar.isSelected()) {
-			patchwork = new Patchwork(inputFolder, outputFolder, rootPath.resolve("data/"), tempFolder, bridged, yarnMappings[0]);
-		} else {
-			patchwork = new Patchwork(inputFolder, outputFolder, rootPath.resolve("data/"), tempFolder, bridged);
-		}
+		Patchwork patchwork = new Patchwork(inputFolder, outputFolder, rootPath.resolve("/data"), tempFolder, bridged, devMappings);
 
 		int patched = patchwork.patchAndFinish();
 		LOGGER.info("Successfully patched " + patched + " mod(s)!");


### PR DESCRIPTION
I heard ramidzkh had something for this, but I wasn't able to find his branch for it.
If he has something better than this, I'm fine to close this PR and let his take precedent.

This also changes some methods that were `public static` to `private` for now. I'm not sure if this is the best approach yet, but it would be useful for when metadata etc. is split off from patching if things could be stored in class fields instead of playing pass-the-local-variables (return values would either get really messy, or lots of reloading saved files would be needed)