### PR TITLE
Add support for IExtensibleEnum shenanigans

### DIFF
--- a/src/main/java/com/patchworkmc/patch/ExtensibleEnumTransformer.java
+++ b/src/main/java/com/patchworkmc/patch/ExtensibleEnumTransformer.java
@@ -1,0 +1,50 @@
+package com.patchworkmc.patch;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class ExtensibleEnumTransformer extends ClassVisitor {
+	private static final String PATCHWORK_ENUM_HACKS = "com/patchworkmc/api/enumhacks/EnumHacks";
+
+	//enum class -> method name on EnumHacks
+	private static final Map<String, String> redirects = new HashMap<>();
+
+	static {
+		redirects.put("net/minecraft/class_1814", "createRarity"); //Rarity
+		redirects.put("net/minecraft/class_1311", "createEntityCategory"); //EntityCategory
+		redirects.put("net/minecraft/class_3785$class_3786", "createStructurePoolProjection"); //StructurePool.Projection
+		redirects.put("net/minecraft/class_3124$class_3125", "createOreFeatureConfigTarget"); //OreFeatureConfig.Target
+		redirects.put("net/minecraft/class_2582", "createBannerPattern"); //BannerPattern
+		redirects.put("net/minecraft/class_1317$class_1319", "createSpawnRestrictionLocation"); //SpawnRestriction.Location
+		redirects.put("net/minecraft/class_1886", "createEnchantmentTarget"); //EnchantmentTarget
+	}
+
+	public ExtensibleEnumTransformer(ClassVisitor classVisitor) {
+		super(Opcodes.ASM7, classVisitor);
+	}
+
+	@Override
+	public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+		return new MethodTransformer(super.visitMethod(access, name, descriptor, signature, exceptions));
+	}
+
+	private static class MethodTransformer extends MethodVisitor {
+		private MethodTransformer(MethodVisitor parent) {
+			super(Opcodes.ASM7, parent);
+		}
+
+		@Override
+		public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+			if (opcode == Opcodes.INVOKESTATIC && name.equals("create") && redirects.containsKey(owner)) {
+				super.visitMethodInsn(Opcodes.INVOKESTATIC, PATCHWORK_ENUM_HACKS, redirects.get(owner), descriptor, false);
+				return;
+			}
+
+			super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+		}
+	}
+}

--- a/src/main/java/com/patchworkmc/patch/ExtensibleEnumTransformer.java
+++ b/src/main/java/com/patchworkmc/patch/ExtensibleEnumTransformer.java
@@ -43,10 +43,9 @@ public class ExtensibleEnumTransformer extends ClassVisitor {
 
 			if (opcode == Opcodes.INVOKESTATIC && name.equals("create") && (methodName = redirects.get(owner)) != null) {
 				super.visitMethodInsn(Opcodes.INVOKESTATIC, PATCHWORK_ENUM_HACKS, methodName, descriptor, false);
-				return;
+			} else {
+				super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
 			}
-
-			super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
 		}
 	}
 }

--- a/src/main/java/com/patchworkmc/patch/ExtensibleEnumTransformer.java
+++ b/src/main/java/com/patchworkmc/patch/ExtensibleEnumTransformer.java
@@ -10,17 +10,17 @@ import org.objectweb.asm.Opcodes;
 public class ExtensibleEnumTransformer extends ClassVisitor {
 	private static final String PATCHWORK_ENUM_HACKS = "com/patchworkmc/api/enumhacks/EnumHacks";
 
-	//enum class -> method name on EnumHacks
+	// enum class -> method name on EnumHacks
 	private static final Map<String, String> redirects = new HashMap<>();
 
 	static {
-		redirects.put("net/minecraft/class_1814", "createRarity"); //Rarity
-		redirects.put("net/minecraft/class_1311", "createEntityCategory"); //EntityCategory
-		redirects.put("net/minecraft/class_3785$class_3786", "createStructurePoolProjection"); //StructurePool.Projection
-		redirects.put("net/minecraft/class_3124$class_3125", "createOreFeatureConfigTarget"); //OreFeatureConfig.Target
-		redirects.put("net/minecraft/class_2582", "createBannerPattern"); //BannerPattern
-		redirects.put("net/minecraft/class_1317$class_1319", "createSpawnRestrictionLocation"); //SpawnRestriction.Location
-		redirects.put("net/minecraft/class_1886", "createEnchantmentTarget"); //EnchantmentTarget
+		redirects.put("net/minecraft/class_1814", "createRarity"); // Rarity
+		redirects.put("net/minecraft/class_1311", "createEntityCategory"); // EntityCategory
+		redirects.put("net/minecraft/class_3785$class_3786", "createStructurePoolProjection"); // StructurePool.Projection
+		redirects.put("net/minecraft/class_3124$class_3125", "createOreFeatureConfigTarget"); // OreFeatureConfig.Target
+		redirects.put("net/minecraft/class_2582", "createBannerPattern"); // BannerPattern
+		redirects.put("net/minecraft/class_1317$class_1319", "createSpawnRestrictionLocation"); // SpawnRestriction.Location
+		redirects.put("net/minecraft/class_1886", "createEnchantmentTarget"); // EnchantmentTarget
 	}
 
 	public ExtensibleEnumTransformer(ClassVisitor classVisitor) {
@@ -39,8 +39,10 @@ public class ExtensibleEnumTransformer extends ClassVisitor {
 
 		@Override
 		public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
-			if (opcode == Opcodes.INVOKESTATIC && name.equals("create") && redirects.containsKey(owner)) {
-				super.visitMethodInsn(Opcodes.INVOKESTATIC, PATCHWORK_ENUM_HACKS, redirects.get(owner), descriptor, false);
+			String methodName;
+
+			if (opcode == Opcodes.INVOKESTATIC && name.equals("create") && (methodName = redirects.get(owner)) != null) {
+				super.visitMethodInsn(Opcodes.INVOKESTATIC, PATCHWORK_ENUM_HACKS, methodName, descriptor, false);
 				return;
 			}
 

--- a/src/main/java/com/patchworkmc/transformer/PatchworkTransformer.java
+++ b/src/main/java/com/patchworkmc/transformer/PatchworkTransformer.java
@@ -38,6 +38,7 @@ import com.patchworkmc.objectholder.ObjectHolderGenerator;
 import com.patchworkmc.objectholder.ObjectHolderScanner;
 import com.patchworkmc.objectholder.initialization.RegisterObjectHolders;
 import com.patchworkmc.patch.BlockSettingsTransformer;
+import com.patchworkmc.patch.ExtensibleEnumTransformer;
 import com.patchworkmc.patch.ItemGroupTransformer;
 import com.patchworkmc.transformer.initialization.ConstructTargetMod;
 
@@ -115,8 +116,9 @@ public class PatchworkTransformer implements BiConsumer<String, byte[]> {
 
 		ItemGroupTransformer itemGroupTransformer = new ItemGroupTransformer(eventHandlerScanner);
 		BlockSettingsTransformer blockSettingsTransformer = new BlockSettingsTransformer(itemGroupTransformer);
+		ExtensibleEnumTransformer extensibleEnumTransformer = new ExtensibleEnumTransformer(blockSettingsTransformer);
 
-		reader.accept(blockSettingsTransformer, ClassReader.EXPAND_FRAMES);
+		reader.accept(extensibleEnumTransformer, ClassReader.EXPAND_FRAMES);
 
 		ClassWriter writer = new ClassWriter(0);
 


### PR DESCRIPTION
Patcher side of the enum shenanigans. This is much simpler, being just a simple remap from Forge's `create` on each enum to the specifically named `createEnumName` methods on EnumHacks (see https://github.com/PatchworkMC/patchwork-api/pull/47)