### PR TITLE
Better events, ObjectHolder improvements, overall reduce log spam

### DIFF
--- a/src/main/java/com/patchworkmc/annotation/StringAnnotationHandler.java
+++ b/src/main/java/com/patchworkmc/annotation/StringAnnotationHandler.java
@@ -17,8 +17,16 @@ public class StringAnnotationHandler extends AnnotationVisitor {
 		this("value", value);
 	}
 
+	public StringAnnotationHandler(AnnotationVisitor parent, Consumer<String> value) {
+		this(parent, "value", value);
+	}
+
 	public StringAnnotationHandler(String expected, Consumer<String> value) {
-		super(Opcodes.ASM7);
+		this(null, expected, value);
+	}
+
+	public StringAnnotationHandler(AnnotationVisitor parent, String expected, Consumer<String> value) {
+		super(Opcodes.ASM7, parent);
 
 		this.valueConsumer = value;
 		this.expected = expected;

--- a/src/main/java/com/patchworkmc/event/EventSubclassTransformer.java
+++ b/src/main/java/com/patchworkmc/event/EventSubclassTransformer.java
@@ -1,0 +1,102 @@
+package com.patchworkmc.event;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import com.patchworkmc.Patchwork;
+
+/**
+ * Processes Cancelable and HasResult annotations, strips getListenerList and getParentListenerList
+  */
+public class EventSubclassTransformer extends ClassVisitor {
+	private static final String CANCELABLE = "Lnet/minecraftforge/eventbus/api/Cancelable;";
+	private static final String IS_CANCELABLE = "isCancelable";
+	private static final String IS_CANCELABLE_DESCRIPTOR = "()Z";
+	private static final String GET_LISTENER_LIST = "getListenerList";
+	private static final String GET_PARENT_LISTENER_LIST = "getParentListenerList";
+	private static final String GET_LISTENER_LIST_DESCRIPTOR = "()Lnet/minecraftforge/eventbus/ListenerList;";
+
+	private boolean hasCancelable;
+	private boolean cancelable;
+	private String className;
+
+	public EventSubclassTransformer(ClassVisitor parent) {
+		super(Opcodes.ASM7, parent);
+	}
+
+	@Override
+	public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+		super.visit(version, access, name, signature, superName, interfaces);
+
+		this.className = name;
+	}
+
+	@Override
+	public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+		if (descriptor.equals(CANCELABLE)) {
+			cancelable = true;
+
+			return null;
+		}
+
+		return super.visitAnnotation(descriptor, visible);
+	}
+
+	@Override
+	public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+		if (name.equals(IS_CANCELABLE) && descriptor.equals(IS_CANCELABLE_DESCRIPTOR)) {
+			hasCancelable = true;
+		}
+
+		// Strip getListenerList and getParentListenerList to significantly simplify the logic in Patchwork EventBus.
+		if (name.equals(GET_LISTENER_LIST) && descriptor.equals(GET_LISTENER_LIST_DESCRIPTOR)) {
+			Patchwork.LOGGER.warn("Stripping %s from %s (an assumed Event class)", GET_LISTENER_LIST, className);
+
+			return null;
+		}
+
+		if (name.equals(GET_PARENT_LISTENER_LIST) && descriptor.equals(GET_LISTENER_LIST_DESCRIPTOR)) {
+			Patchwork.LOGGER.warn("Stripping %s from %s (an assumed Event class)", GET_PARENT_LISTENER_LIST, className);
+
+			return null;
+		}
+
+		return super.visitMethod(access, name, descriptor, signature, exceptions);
+	}
+
+	@Override
+	public void visitEnd() {
+		if (cancelable && !hasCancelable) {
+			visitCancelable();
+		}
+
+		super.visitEnd();
+	}
+
+	/**
+	 * Adds the following code:
+	 * <pre>
+	 * public boolean isCancelable() {
+	 *     return true;
+	 * }
+	 * </pre>
+	 */
+	private void visitCancelable() {
+		MethodVisitor isCancelable = super.visitMethod(Opcodes.ACC_PUBLIC, IS_CANCELABLE, IS_CANCELABLE_DESCRIPTOR, null, null);
+
+		if (isCancelable != null) {
+			AnnotationVisitor override = isCancelable.visitAnnotation("Ljava/lang/Override;", true);
+
+			if (override != null) {
+				override.visitEnd();
+			}
+
+			isCancelable.visitInsn(Opcodes.ICONST_1);
+			isCancelable.visitInsn(Opcodes.IRETURN);
+			isCancelable.visitMaxs(2, 0);
+			isCancelable.visitEnd();
+		}
+	}
+}

--- a/src/main/java/com/patchworkmc/event/EventSubclassTransformer.java
+++ b/src/main/java/com/patchworkmc/event/EventSubclassTransformer.java
@@ -6,7 +6,7 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
 /**
- * Processes Cancelable and HasResult annotations, strips getListenerList and getParentListenerList.
+ * Processes Cancelable and HasResult annotations, blocks overriding getListenerList and getParentListenerList.
  */
 public class EventSubclassTransformer extends ClassVisitor {
 	private static final String CANCELABLE_ANNOTATION = "Lnet/minecraftforge/eventbus/api/Cancelable;";

--- a/src/main/java/com/patchworkmc/event/EventSubclassTransformer.java
+++ b/src/main/java/com/patchworkmc/event/EventSubclassTransformer.java
@@ -8,8 +8,8 @@ import org.objectweb.asm.Opcodes;
 import com.patchworkmc.Patchwork;
 
 /**
- * Processes Cancelable and HasResult annotations, strips getListenerList and getParentListenerList
-  */
+ * Processes Cancelable and HasResult annotations, strips getListenerList and getParentListenerList.
+ */
 public class EventSubclassTransformer extends ClassVisitor {
 	private static final String CANCELABLE_ANNOTATION = "Lnet/minecraftforge/eventbus/api/Cancelable;";
 	private static final String HAS_RESULT_ANNOTATION = "Lnet/minecraftforge/eventbus/api/Event$HasResult;";
@@ -43,9 +43,9 @@ public class EventSubclassTransformer extends ClassVisitor {
 			cancelable = true;
 
 			return null;
-		} else if(descriptor.equals(HAS_RESULT_ANNOTATION)) {
+		} else if (descriptor.equals(HAS_RESULT_ANNOTATION)) {
 			hasResult = true;
-			
+
 			return null;
 		}
 
@@ -91,12 +91,13 @@ public class EventSubclassTransformer extends ClassVisitor {
 	}
 
 	/**
-	 * Adds the following code:
-	 * <pre>
+	 * Adds a public marker method that returns true.
+	 *
+	 * <p>It appears like so: <pre>
 	 * public boolean name() {
 	 *     return true;
 	 * }
-	 * </pre>
+	 * </pre></p>
 	 *
 	 * @param name The name of the generated method
 	 */

--- a/src/main/java/com/patchworkmc/mapping/remapper/AmbiguousMappingException.java
+++ b/src/main/java/com/patchworkmc/mapping/remapper/AmbiguousMappingException.java
@@ -1,0 +1,7 @@
+package com.patchworkmc.mapping.remapper;
+
+public class AmbiguousMappingException extends Exception {
+	public AmbiguousMappingException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/patchworkmc/mapping/remapper/NaiveRemapper.java
+++ b/src/main/java/com/patchworkmc/mapping/remapper/NaiveRemapper.java
@@ -88,17 +88,15 @@ public class NaiveRemapper {
 	/**
 	 * @deprecated Because of java generics, inheritence, synthetics, and recompiling, Forge matches methods that override another method but change
 	 *  return type T to class_XXX directly, but Fabric matches to the synthetic. Runtime mappings should be used here instead.
-	 * @param volde
-	 * @return
 	 */
 	@Deprecated
-	public String getMethod(String volde) {
+	public String getMethod(String volde) throws AmbiguousMappingException {
 		if (!volde.startsWith("func_")) {
 			throw new IllegalArgumentException("Cannot remap methods not starting with func_: " + volde);
 		}
 
 		if (blacklistedMethods.contains(volde)) {
-			throw new UnsupportedOperationException("Cannot remap method name " + volde + " because that method name could map to multiple targets!");
+			throw new AmbiguousMappingException("Cannot remap method name " + volde + " because that method name could map to multiple targets!");
 		}
 
 		return methods.getOrDefault(volde, volde);

--- a/src/main/java/com/patchworkmc/objectholder/initialization/RegisterObjectHolders.java
+++ b/src/main/java/com/patchworkmc/objectholder/initialization/RegisterObjectHolders.java
@@ -1,6 +1,5 @@
 package com.patchworkmc.objectholder.initialization;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -12,26 +11,13 @@ import com.patchworkmc.Patchwork;
 import com.patchworkmc.objectholder.ObjectHolder;
 
 public class RegisterObjectHolders implements Consumer<MethodVisitor> {
-	private static HashMap<String, String> classToRegistry = new HashMap<>();
-	private static HashMap<String, String> classToRegistryType = new HashMap<>();
-
-	static {
-		addMapping("class_2248", "field_11146", "Lnet/minecraft/class_2348;"); // Block -> BLOCK
-		addMapping("class_1959", "field_11153", "Lnet/minecraft/class_2378;"); // Biome -> BIOME
-		addMapping("class_1792", "field_11142", "Lnet/minecraft/class_2348;"); // Item -> ITEM
-		addMapping("class_3523", "field_11147", "Lnet/minecraft/class_2378;"); // SurfaceBuilder -> SURFACE_BUILDER
-		addMapping("class_1865", "field_17598", "Lnet/minecraft/class_2378;"); // RecipeSerializer -> RECIPE_SERIALIZER
-	}
+	// net.minecraft.util.Registry
+	private static final String REGISTRY = "net/minecraft/class_2378";
 
 	private Iterable<Map.Entry<String, ObjectHolder>> objectHolderEntries;
 
 	public RegisterObjectHolders(Iterable<Map.Entry<String, ObjectHolder>> objectHolderEntries) {
 		this.objectHolderEntries = objectHolderEntries;
-	}
-
-	private static void addMapping(String clazz, String registry, String registryType) {
-		classToRegistry.put("Lnet/minecraft/" + clazz + ";", registry);
-		classToRegistryType.put("Lnet/minecraft/" + clazz + ";", registryType);
 	}
 
 	@Override
@@ -40,8 +26,7 @@ public class RegisterObjectHolders implements Consumer<MethodVisitor> {
 			String shimName = entry.getKey();
 			ObjectHolder holder = entry.getValue();
 
-			String registry = classToRegistry.get(holder.getDescriptor());
-			String registryType = classToRegistryType.get(holder.getDescriptor());
+			VanillaRegistry registry = VanillaRegistry.get(holder.getDescriptor());
 
 			String registerDescriptor = "(Lnet/minecraft/class_2378;Ljava/lang/String;Ljava/lang/String;Ljava/util/function/Consumer;)V";
 
@@ -49,14 +34,13 @@ public class RegisterObjectHolders implements Consumer<MethodVisitor> {
 
 			if (registry == null) {
 				if (holder.getDescriptor().startsWith("Lnet/minecraft/class_")) {
-					Patchwork.LOGGER.warn("Dont know what registry the minecraft class " + holder.getDescriptor() + " belongs to, falling back to dynamic!");
+					Patchwork.LOGGER.warn("Don't know what registry the minecraft class " + holder.getDescriptor() + " belongs to, falling back to dynamic!");
 				}
 
 				method.visitLdcInsn(Type.getObjectType(holder.getDescriptor().substring(1, holder.getDescriptor().length() - 1)));
 				registerDescriptor = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;Ljava/util/function/Consumer;)V";
 			} else {
-				method.visitFieldInsn(Opcodes.GETSTATIC, "net/minecraft/class_2378", // net.minecraft.util.Registry
-						registry, registryType);
+				method.visitFieldInsn(Opcodes.GETSTATIC, REGISTRY, registry.getField(), registry.getFieldDescriptor());
 			}
 
 			method.visitLdcInsn(holder.getNamespace());

--- a/src/main/java/com/patchworkmc/objectholder/initialization/VanillaRegistry.java
+++ b/src/main/java/com/patchworkmc/objectholder/initialization/VanillaRegistry.java
@@ -6,12 +6,12 @@ public final class VanillaRegistry {
 	private static final HashMap<String, VanillaRegistry> REGISTRIES = new HashMap<>();
 
 	/**
-	 * net.minecraft.util.Registry
+	 * Intermediary for {@code net.minecraft.util.Registry}.
 	 */
 	private static final String REGISTRY_DESCRIPTOR = "Lnet/minecraft/class_2378;";
 
 	/**
-	 * net.minecraft.util.registry.DefaultedRegistry
+	 * Intermediary for {@code net.minecraft.util.registry.DefaultedRegistry}.
 	 */
 	private static final String DEFAULTED_REGISTRY_DESCRIPTOR = "Lnet/minecraft/class_2348;";
 
@@ -64,7 +64,7 @@ public final class VanillaRegistry {
 	}
 
 	private static void addMapping(String clazz, String registry, boolean defaulted) {
-		REGISTRIES.put("Lnet/minecraft/" + clazz + ";" , new VanillaRegistry(registry, defaulted));
+		REGISTRIES.put("Lnet/minecraft/" + clazz + ";", new VanillaRegistry(registry, defaulted));
 	}
 
 	static VanillaRegistry get(String descriptor) {

--- a/src/main/java/com/patchworkmc/objectholder/initialization/VanillaRegistry.java
+++ b/src/main/java/com/patchworkmc/objectholder/initialization/VanillaRegistry.java
@@ -1,0 +1,81 @@
+package com.patchworkmc.objectholder.initialization;
+
+import java.util.HashMap;
+
+public final class VanillaRegistry {
+	private static final HashMap<String, VanillaRegistry> REGISTRIES = new HashMap<>();
+
+	/**
+	 * net.minecraft.util.Registry
+	 */
+	private static final String REGISTRY_DESCRIPTOR = "Lnet/minecraft/class_2378;";
+
+	/**
+	 * net.minecraft.util.registry.DefaultedRegistry
+	 */
+	private static final String DEFAULTED_REGISTRY_DESCRIPTOR = "Lnet/minecraft/class_2348;";
+
+	private String field;
+	private boolean defaulted;
+
+	private VanillaRegistry(String field, boolean defaulted) {
+		this.field = field;
+		this.defaulted = defaulted;
+	}
+
+	static {
+		addMapping("class_2248", "field_11146", true); // Block -> BLOCK
+		addMapping("class_1792", "field_11142", true); // Item -> ITEM
+		addMapping("class_4168", "field_18796", false); // Activity -> ACTIVITY
+		addMapping("class_1959", "field_11153", false); // Biome -> BIOME
+		addMapping("class_1969", "field_11151", false); // BiomeSourceType -> BIOME_SOURCE_TYPE
+		addMapping("class_2591", "field_11137", false); // BlockEntityType -> BLOCK_ENTITY
+		addMapping("class_2939", "field_11157", false); // Carver -> CARVER
+		addMapping("class_2798", "field_11149", false); // ChunkGeneratorType -> CHUNK_GENERATOR_TYPE
+		addMapping("class_2806", "field_16643", true); // ChunkStatus -> CHUNK_STATUS
+		addMapping("class_2960", "field_11158", false); // Identifier -> CUSTOM_STAT
+		addMapping("class_3284", "field_11148", false); // Decorator -> DECORATOR
+		addMapping("class_2874", "field_11155", false); // DimensionType -> DIMENSION
+		addMapping("class_1887", "field_11160", false); // Enchantment -> ENCHANTMENT
+		addMapping("class_1299", "field_11145", true); // EntityType -> ENTITY_TYPE
+		addMapping("class_3031", "field_11138", false); // Feature -> FEATURE
+		addMapping("class_3611", "field_11154", true); // Fluid -> FLUID
+		addMapping("class_4140", "field_18793", true); // MemoryModuleType -> MEMORY_MODULE_TYPE
+		addMapping("class_3917", "field_17429", false); // ContainerType -> CONTAINER
+		addMapping("class_1291", "field_11159", false); // StatusEffect -> STATUS_EFFECT
+		addMapping("class_1535", "field_11150", true); // PaintingMotive -> MOTIVE
+		addMapping("class_2396", "field_11141", false); // ParticleType -> PARTICLE_TYPE
+		addMapping("class_4158", "field_18792", true); // PointOfInterestType
+		addMapping("class_1842", "field_11143", true); // Potion -> POTION
+		addMapping("class_1865", "field_17598", false); // RecipeSerializer -> RECIPE_SERIALIZER
+		addMapping("class_3956", "field_17597", false); // RecipeType -> RECIPE_TYPE
+		addMapping("class_3827", "field_16792", false); // RuleTestType -> RULE_TEST
+		addMapping("class_4170", "field_18795", false); // Schedule -> SCHEDULE
+		addMapping("class_4149", "field_18794", true); // SensorType -> SENSOR_TYPE
+		addMapping("class_3414", "field_11156", false); // SoundEvent -> SOUND_EVENT
+		addMapping("class_3448", "field_11152", false); // StatType -> STAT_TYPE
+		addMapping("class_3195", "field_16644", false); // StructureFeature -> STRUCTURE_FEATURE
+		addMapping("class_3773", "field_16645", false); // StructurePieceType -> STRUCTURE_PIECE
+		addMapping("class_3816", "field_16793", false); // StructurePoolElementType -> STRUCTURE_POOL_ELEMENT
+		addMapping("class_3828", "field_16794", false); // StructureProcessorType -> STRUCTURE_PROCESSOR
+		addMapping("class_3523", "field_11147", false); // SurfaceBuilder -> SURFACE_BUILDER
+		addMapping("class_3852", "field_17167", true); // VillagerProfession
+		addMapping("class_3854", "field_17166", true); // VillagerType
+	}
+
+	private static void addMapping(String clazz, String registry, boolean defaulted) {
+		REGISTRIES.put("Lnet/minecraft/" + clazz + ";" , new VanillaRegistry(registry, defaulted));
+	}
+
+	static VanillaRegistry get(String descriptor) {
+		return REGISTRIES.get(descriptor);
+	}
+
+	String getField() {
+		return field;
+	}
+
+	String getFieldDescriptor() {
+		return defaulted ? DEFAULTED_REGISTRY_DESCRIPTOR : REGISTRY_DESCRIPTOR;
+	}
+}

--- a/src/main/java/com/patchworkmc/patch/StringConstantRemapper.java
+++ b/src/main/java/com/patchworkmc/patch/StringConstantRemapper.java
@@ -5,6 +5,8 @@ import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
+import com.patchworkmc.Patchwork;
+import com.patchworkmc.mapping.remapper.AmbiguousMappingException;
 import com.patchworkmc.mapping.remapper.NaiveRemapper;
 
 /**
@@ -41,7 +43,13 @@ public class StringConstantRemapper extends ClassVisitor {
 		if (name.startsWith("field_")) {
 			name = remapper.getField(name);
 		} else if (name.startsWith("func_")) {
-			name = remapper.getMethod(name);
+			try {
+				name = remapper.getMethod(name);
+			} catch (AmbiguousMappingException e) {
+				Patchwork.LOGGER.warn("Failed to remap string constant: %s", e.getMessage());
+
+				return name;
+			}
 		} else {
 			name = remapper.getClass(name);
 		}

--- a/src/main/java/com/patchworkmc/transformer/PatchworkTransformer.java
+++ b/src/main/java/com/patchworkmc/transformer/PatchworkTransformer.java
@@ -26,6 +26,7 @@ import com.patchworkmc.access.ModAccessTransformer;
 import com.patchworkmc.annotation.AnnotationProcessor;
 import com.patchworkmc.annotation.AnnotationStorage;
 import com.patchworkmc.event.EventBusSubscriber;
+import com.patchworkmc.event.EventSubclassTransformer;
 import com.patchworkmc.event.EventHandlerScanner;
 import com.patchworkmc.event.SubscribeEvent;
 import com.patchworkmc.event.generator.InstanceEventRegistrarGenerator;
@@ -124,8 +125,9 @@ public class PatchworkTransformer implements BiConsumer<String, byte[]> {
 		ItemGroupTransformer itemGroupTransformer = new ItemGroupTransformer(eventHandlerScanner);
 		BlockSettingsTransformer blockSettingsTransformer = new BlockSettingsTransformer(itemGroupTransformer);
 		ExtensibleEnumTransformer extensibleEnumTransformer = new ExtensibleEnumTransformer(blockSettingsTransformer);
+		EventSubclassTransformer eventSubclassTransformer = new EventSubclassTransformer(extensibleEnumTransformer);
 
-		reader.accept(extensibleEnumTransformer, ClassReader.EXPAND_FRAMES);
+		reader.accept(eventSubclassTransformer, ClassReader.EXPAND_FRAMES);
 
 		ClassWriter writer = new ClassWriter(0);
 


### PR DESCRIPTION
* Process Event subclasses properly (a companion for https://github.com/PatchworkMC/EventBus/pull/4)
    * Strip getListenerList and getParentListenerList to significantly simplify the logic in Patchwork EventBus.
    * Process `@Cancelable` and `@HasResult` properly
* Better error handling for ambiguous method mappings in StringConstantRemapper, those constants generate a warning instead of failing hard
* ObjectHolder improvements
     * All vanilla registries now have their data entered, so Patcher can generate direct field references instead of requiring a dynamic Class -> Registry lookup
     * Fixed a rare inconsistency: `@Mod` now provides a default mod ID to `@ObjectHolder` annotations