### PR TITLE
Disallow packages properly

### DIFF
--- a/src/main/java/net/patchworkmc/patcher/transformer/PatchworkTransformer.java
+++ b/src/main/java/net/patchworkmc/patcher/transformer/PatchworkTransformer.java
@@ -83,11 +83,11 @@ public class PatchworkTransformer implements BiConsumer<String, byte[]> {
 			throw new IllegalArgumentException("Name should not end with .class");
 		}
 
-		if (name.startsWith("net/minecraft")) {
+		if (name.startsWith("net/minecraft/")) {
 			throw new IllegalArgumentException("Mod jars are not allowed to contain classes in Minecraft's package!");
 		}
 
-		if (name.startsWith("java")) {
+		if (name.startsWith("java/")) {
 			throw new IllegalArgumentException("Mod jars are not allowed to contain classes in Java's package!");
 		}
 


### PR DESCRIPTION
Mods (such as WorldEdit) may decide to have stuff in packages which start with java, such as javax.annotation