### PR TITLE
Added KeyBinding replacement

### DIFF
--- a/src/main/java/net/patchworkmc/patcher/patch/KeyBindingsTransformer.java
+++ b/src/main/java/net/patchworkmc/patcher/patch/KeyBindingsTransformer.java
@@ -9,7 +9,7 @@ public class KeyBindingsTransformer extends ClassVisitor {
 	private static final String KEY_BINDING = "net/minecraft/class_304";
 
 	// Patchwork's replacement key binding class
-	private static final String PATCHWORK_KEY_BINDING = "net/patchworkmc/impl/keybindings/PatchworkKeybinding";
+	private static final String PATCHWORK_KEY_BINDING = "net/patchworkmc/api/keybindings/PatchworkKeyBinding";
 
 	public KeyBindingsTransformer(ClassVisitor parent) {
 		super(Opcodes.ASM7, parent);

--- a/src/main/java/net/patchworkmc/patcher/patch/KeyBindingsTransformer.java
+++ b/src/main/java/net/patchworkmc/patcher/patch/KeyBindingsTransformer.java
@@ -36,7 +36,7 @@ public class KeyBindingsTransformer extends ClassVisitor {
 
 		@Override
 		public void visitTypeInsn(int opcode, String type) {
-			if (type.equals(KEY_BINDING)) {
+			if (type.equals(KEY_BINDING) && opcode == Opcodes.NEW) {
 				super.visitTypeInsn(opcode, PATCHWORK_KEY_BINDING);
 			} else {
 				super.visitTypeInsn(opcode, type);

--- a/src/main/java/net/patchworkmc/patcher/patch/KeyBindingsTransformer.java
+++ b/src/main/java/net/patchworkmc/patcher/patch/KeyBindingsTransformer.java
@@ -1,0 +1,46 @@
+package net.patchworkmc.patcher.patch;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class KeyBindingsTransformer extends ClassVisitor {
+	// The intermediary name for KeyBinding
+	private static final String KEY_BINDING = "net/minecraft/class_304";
+
+	// Patchwork's replacement key binding class
+	private static final String PATCHWORK_KEY_BINDING = "net/patchworkmc/impl/keybindings/PatchworkKeybinding";
+
+	public KeyBindingsTransformer(ClassVisitor parent) {
+		super(Opcodes.ASM7, parent);
+	}
+
+	@Override
+	public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+		return new MethodTransformer(super.visitMethod(access, name, descriptor, signature, exceptions));
+	}
+
+	private static class MethodTransformer extends MethodVisitor {
+		private MethodTransformer(MethodVisitor parent) {
+			super(Opcodes.ASM7, parent);
+		}
+
+		@Override
+		public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+			if (opcode == Opcodes.INVOKESPECIAL && name.equals("<init>") && owner.equals(KEY_BINDING)) {
+				super.visitMethodInsn(opcode, PATCHWORK_KEY_BINDING, name, descriptor, isInterface);
+			} else {
+				super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+			}
+		}
+
+		@Override
+		public void visitTypeInsn(int opcode, String type) {
+			if (type.equals(KEY_BINDING)) {
+				super.visitTypeInsn(opcode, PATCHWORK_KEY_BINDING);
+			} else {
+				super.visitTypeInsn(opcode, type);
+			}
+		}
+	}
+}

--- a/src/main/java/net/patchworkmc/patcher/transformer/PatchworkTransformer.java
+++ b/src/main/java/net/patchworkmc/patcher/transformer/PatchworkTransformer.java
@@ -38,6 +38,7 @@ import net.patchworkmc.patcher.patch.BiomeLayersTransformer;
 import net.patchworkmc.patcher.patch.BlockSettingsTransformer;
 import net.patchworkmc.patcher.patch.ExtensibleEnumTransformer;
 import net.patchworkmc.patcher.patch.ItemGroupTransformer;
+import net.patchworkmc.patcher.patch.KeyBindingsTransformer;
 import net.patchworkmc.patcher.patch.LevelGeneratorTypeTransformer;
 import net.patchworkmc.patcher.patch.StringConstantRemapper;
 import net.patchworkmc.patcher.transformer.initialization.ConstructTargetMod;
@@ -109,7 +110,8 @@ public class PatchworkTransformer implements BiConsumer<String, byte[]> {
 		ExtensibleEnumTransformer extensibleEnumTransformer = new ExtensibleEnumTransformer(biomeLayersTransformer);
 		EventSubclassTransformer eventSubclassTransformer = new EventSubclassTransformer(extensibleEnumTransformer);
 		LevelGeneratorTypeTransformer levelGeneratorTypeTransformer = new LevelGeneratorTypeTransformer(eventSubclassTransformer);
-		StringConstantRemapper stringRemapperTransformer = new StringConstantRemapper(levelGeneratorTypeTransformer, remapper.getNaiveRemapper());
+		KeyBindingsTransformer keyBindingsTransformer = new KeyBindingsTransformer(levelGeneratorTypeTransformer);
+		StringConstantRemapper stringRemapperTransformer = new StringConstantRemapper(keyBindingsTransformer, remapper.getNaiveRemapper());
 
 		reader.accept(stringRemapperTransformer, ClassReader.EXPAND_FRAMES);
 


### PR DESCRIPTION
Replaces all instances of KeyBinding initialization with a PatchworkKeyBinding initialization to support the extra constructors forge adds to the class and allow registration with Fabric API. Fair warning, this is my first time using ASM and while I've checked and it works I have no idea if this is considered good form.

This requires an API PR, namely https://github.com/PatchworkMC/patchwork-api/pull/154.