### PR TITLE
Refactor downloading resources for patching

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,13 +63,18 @@ dependencies {
 	// Other dependencies
 	implementation 'net.fabricmc:tiny-remapper:0.2.1.62'
 
+	// Needed for merging the client and server jar
+	implementation ('net.fabricmc:stitch:0.4.6+build.74') {
+		exclude module: 'enigma'
+	}
+
 	implementation 'com.electronwill.night-config:toml:3.6.0'
 
 	implementation 'com.google.code.gson:gson:2.8.5'
 
 	implementation 'org.fusesource.jansi:jansi:1.18'
 
-	implementation "commons-io:commons-io:2.6"
+	implementation "commons-io:commons-io:2.7"
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/src/main/java/net/patchworkmc/patcher/Patchwork.java
+++ b/src/main/java/net/patchworkmc/patcher/Patchwork.java
@@ -1,7 +1,6 @@
 package net.patchworkmc.patcher;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -42,27 +41,23 @@ import net.patchworkmc.patcher.annotation.AnnotationStorage;
 import net.patchworkmc.patcher.jar.ForgeModJar;
 import net.patchworkmc.patcher.manifest.converter.accesstransformer.AccessTransformerConverter;
 import net.patchworkmc.patcher.manifest.converter.mod.ModManifestConverter;
-import net.patchworkmc.patcher.mapping.BridgedMappings;
 import net.patchworkmc.patcher.mapping.MemberInfo;
-import net.patchworkmc.patcher.mapping.RawMapping;
-import net.patchworkmc.patcher.mapping.TinyWriter;
-import net.patchworkmc.patcher.mapping.Tsrg;
-import net.patchworkmc.patcher.mapping.TsrgClass;
-import net.patchworkmc.patcher.mapping.TsrgMappings;
 import net.patchworkmc.patcher.mapping.remapper.ManifestRemapperImpl;
 import net.patchworkmc.patcher.mapping.remapper.PatchworkRemapper;
 import net.patchworkmc.patcher.transformer.PatchworkTransformer;
+import net.patchworkmc.patcher.util.ResourceDownloadUtil;
+import net.patchworkmc.patcher.util.VersionUtil;
 
 public class Patchwork {
+	// TODO use a "standard" log4j logger
 	public static final Logger LOGGER = LogManager.getFormatterLogger("Patchwork");
 	private static String version = "1.14.4";
 
 	private byte[] patchworkGreyscaleIcon;
 
-	private Path inputDir, outputDir, dataDir, tempDir;
-	private Path clientJarSrg;
+	private Path inputDir, outputDir, tempDir;
+	private Path minecraftJarSrg;
 	private IMappingProvider primaryMappings;
-	private List<IMappingProvider> devMappings;
 	private PatchworkRemapper patchworkRemapper;
 	private Remapper accessTransformerRemapper;
 	private final MemberInfo memberInfo;
@@ -71,22 +66,17 @@ public class Patchwork {
 	/**
 	 * @param inputDir
 	 * @param outputDir
-	 * @param dataDir
 	 * @param tempDir
 	 * @param primaryMappings mappings in the format of {@code source -> target}
 	 * @param targetFirstMappings mappings in the format of {@code target -> any}
-	 * @param devMappings any additional mappings needed after the main remapping stage (Doesn't work for ATs or reflection)
 	 */
-	public Patchwork(Path inputDir, Path outputDir, Path dataDir, Path tempDir, IMappingProvider primaryMappings, IMappingProvider targetFirstMappings, List<IMappingProvider> devMappings) {
+	public Patchwork(Path inputDir, Path outputDir, Path minecraftJar, Path tempDir, IMappingProvider primaryMappings, IMappingProvider targetFirstMappings) {
 		this.inputDir = inputDir;
 		this.outputDir = outputDir;
-		this.dataDir = dataDir;
 		this.tempDir = tempDir;
-		this.clientJarSrg = dataDir.resolve(version + "-client+srg.jar");
+		this.minecraftJarSrg = minecraftJar;
 		this.primaryMappings = primaryMappings;
 		this.memberInfo = new MemberInfo(targetFirstMappings);
-
-		this.devMappings = devMappings;
 
 		try (InputStream inputStream = Patchwork.class.getResourceAsStream("/patchwork-icon-greyscale.png")) {
 			this.patchworkGreyscaleIcon = new byte[inputStream.available()];
@@ -115,8 +105,6 @@ public class Patchwork {
 			try {
 				transformMod(mod);
 				count++;
-
-				generateDevJarsForOneModJar(mod);
 			} catch (Exception ex) {
 				LOGGER.throwing(Level.ERROR, ex);
 			}
@@ -193,7 +181,7 @@ public class Patchwork {
 		JsonArray patchworkEntrypoints = new JsonArray();
 
 		try {
-			remapper = remap(primaryMappings, jarPath, transformer, clientJarSrg);
+			remapper = remap(primaryMappings, jarPath, transformer, minecraftJarSrg);
 
 			// Write the ForgeInitializer
 			transformer.finish(patchworkEntrypoints::add);
@@ -358,64 +346,47 @@ public class Patchwork {
 		}
 	}
 
-	private void generateDevJarsForOneModJar(ForgeModJar mod) {
-		Path relativeJarPath = inputDir.relativize(mod.getJarPath());
-		Path patchedJarPath = outputDir.resolve(relativeJarPath);
-		String modName = patchedJarPath.getFileName().toString().split("\\.jar")[0];
+	public static Patchwork create(Path inputDir, Path outputDir, Path dataDir) throws IOException, URISyntaxException {
+		Files.createDirectories(inputDir);
+		Files.createDirectories(outputDir);
+		Files.createDirectories(dataDir);
+		Path tempDir = Files.createTempDirectory(new File(System.getProperty("java.io.tmpdir")).toPath(), "patchwork-patcher-");
 
-		for (int i = 0; i < devMappings.size(); i++) {
-			IMappingProvider mappingProvider = devMappings.get(i);
+		ResourceDownloadUtil downloader = new ResourceDownloadUtil();
 
-			try {
-				remap(
-						mappingProvider, patchedJarPath,
-						outputDir.resolve(modName + "-dev-" + i + ".jar"),
-						dataDir.resolve(version + "-client+intermediary.jar")
-				);
-				LOGGER.info("Dev jar generated %s", relativeJarPath);
-			} catch (IOException ex) {
-				LOGGER.throwing(Level.ERROR, ex);
+		Path minecraftJar = dataDir.resolve("minecraft-merged-srg-" + VersionUtil.getMinecraftVersion() + ".jar");
+
+		boolean mappingsCached = false;
+
+		if (!Files.exists(minecraftJar)) {
+			LOGGER.warn("Merged minecraft jar not found, generating one!");
+			downloader.createAndRemapMinecraftJar(minecraftJar);
+			mappingsCached = true;
+			LOGGER.warn("Done");
+		}
+
+		Path mappings = Files.createDirectories(dataDir.resolve("mappings")).resolve("voldemap-bridged-" + VersionUtil.getMinecraftVersion() + ".tiny");
+
+		IMappingProvider bridgedMappings;
+
+		if (!Files.exists(mappings)) {
+			if (!mappingsCached) {
+				LOGGER.warn("Mappings not cached, downloading!");
 			}
-		}
-	}
 
-	public static void main(String[] args) throws Exception {
-		File current = new File(System.getProperty("user.dir"));
-		Path currentPath = current.toPath();
-		File voldemapTiny = new File(current, "data/mappings/voldemap-" + version + ".tiny");
-		List<TsrgClass<RawMapping>> classes = Tsrg.readMappings(new FileInputStream(new File(current, "data/mappings/voldemap-" + version + ".tsrg")));
+			bridgedMappings = downloader.setupAndLoadMappings(mappings);
 
-		IMappingProvider intermediary = TinyUtils.createTinyMappingProvider(currentPath.resolve("data/mappings/intermediary-" + version + ".tiny"), "official", "intermediary");
-		TsrgMappings mappings = new TsrgMappings(classes, intermediary);
-
-		if (!voldemapTiny.exists()) {
-			TinyWriter tinyWriter = new TinyWriter("official", "srg");
-			mappings.load(tinyWriter);
-			String tiny = tinyWriter.toString();
-			Files.write(voldemapTiny.toPath(), tiny.getBytes(StandardCharsets.UTF_8));
-		}
-
-		File voldemapBridged = new File(current, "data/mappings/voldemap-bridged-" + version + ".tiny");
-		IMappingProvider bridged;
-		IMappingProvider bridgedInverted;
-
-		if (!voldemapBridged.exists()) {
-			LOGGER.trace("Generating bridged (srg -> intermediary) tiny mappings");
-
-			TinyWriter tinyWriter = new TinyWriter("srg", "intermediary");
-			bridged = new BridgedMappings(mappings, intermediary);
-			bridged.load(tinyWriter);
-			Files.write(voldemapBridged.toPath(), tinyWriter.toString().getBytes(StandardCharsets.UTF_8));
+			if (!mappingsCached) {
+				LOGGER.warn("Done");
+			}
+		} else if (mappingsCached) {
+			bridgedMappings = downloader.setupAndLoadMappings(null);
 		} else {
-			LOGGER.trace("Using cached bridged (srg -> intermediary) tiny mappings");
-			bridged = TinyUtils.createTinyMappingProvider(voldemapBridged.toPath(), "srg", "intermediary");
+			bridgedMappings = TinyUtils.createTinyMappingProvider(mappings, "srg", "intermediary");
 		}
 
-		bridgedInverted = TinyUtils.createTinyMappingProvider(voldemapBridged.toPath(), "intermediary", "srg");
+		IMappingProvider bridgedInverted = TinyUtils.createTinyMappingProvider(mappings, "intermediary", "srg");
 
-		Path inputDir = Files.createDirectories(currentPath.resolve("input"));
-		Path outputDir = Files.createDirectories(currentPath.resolve("output"));
-		Path tempDir = Files.createTempDirectory(new File(System.getProperty("java.io.tmpdir")).toPath(), "patchwork-patcher-cli");
-		new Patchwork(inputDir, outputDir, currentPath.resolve("data/"), tempDir, bridged, bridgedInverted, Collections.emptyList()).patchAndFinish();
+		return new Patchwork(inputDir, outputDir, minecraftJar, tempDir, bridgedMappings, bridgedInverted);
 	}
 }

--- a/src/main/java/net/patchworkmc/patcher/Patchwork.java
+++ b/src/main/java/net/patchworkmc/patcher/Patchwork.java
@@ -45,7 +45,7 @@ import net.patchworkmc.patcher.mapping.MemberInfo;
 import net.patchworkmc.patcher.mapping.remapper.ManifestRemapperImpl;
 import net.patchworkmc.patcher.mapping.remapper.PatchworkRemapper;
 import net.patchworkmc.patcher.transformer.PatchworkTransformer;
-import net.patchworkmc.patcher.util.ResourceDownloadUtil;
+import net.patchworkmc.patcher.util.ResourceDownloader;
 import net.patchworkmc.patcher.util.VersionUtil;
 
 public class Patchwork {
@@ -352,7 +352,7 @@ public class Patchwork {
 		Files.createDirectories(dataDir);
 		Path tempDir = Files.createTempDirectory(new File(System.getProperty("java.io.tmpdir")).toPath(), "patchwork-patcher-");
 
-		ResourceDownloadUtil downloader = new ResourceDownloadUtil();
+		ResourceDownloader downloader = new ResourceDownloader();
 
 		Path minecraftJar = dataDir.resolve("minecraft-merged-srg-" + VersionUtil.getMinecraftVersion() + ".jar");
 

--- a/src/main/java/net/patchworkmc/patcher/PatchworkCLI.java
+++ b/src/main/java/net/patchworkmc/patcher/PatchworkCLI.java
@@ -1,0 +1,18 @@
+package net.patchworkmc.patcher;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+// TODO: This should be a full CLI instead of just a wrapper with the default options.
+public class PatchworkCLI {
+	public static final Logger LOGGER = LogManager.getLogger(PatchworkCLI.class);
+
+	public static void main(String[] args) throws Exception {
+		Path current = new File(System.getProperty("user.dir")).toPath();
+
+		Patchwork.create(current.resolve("input"), current.resolve("output"), current.resolve("data")).patchAndFinish();
+	}
+}

--- a/src/main/java/net/patchworkmc/patcher/util/ResourceDownloadUtil.java
+++ b/src/main/java/net/patchworkmc/patcher/util/ResourceDownloadUtil.java
@@ -1,0 +1,169 @@
+package net.patchworkmc.patcher.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.fabricmc.stitch.merge.JarMerger;
+import net.fabricmc.tinyremapper.IMappingProvider;
+import net.fabricmc.tinyremapper.TinyUtils;
+
+import net.patchworkmc.patcher.Patchwork;
+import net.patchworkmc.patcher.mapping.BridgedMappings;
+import net.patchworkmc.patcher.mapping.RawMapping;
+import net.patchworkmc.patcher.mapping.TinyWriter;
+import net.patchworkmc.patcher.mapping.Tsrg;
+import net.patchworkmc.patcher.mapping.TsrgClass;
+import net.patchworkmc.patcher.mapping.TsrgMappings;
+
+public class ResourceDownloadUtil {
+	private static final String FORGE_MAVEN = "https://files.minecraftforge.net/maven";
+	private static final String FABRIC_MAVEN = "https://maven.fabricmc.net";
+	private final Path tempDir;
+
+	private static final Logger LOGGER = LogManager.getLogger(ResourceDownloadUtil.class);
+	private IMappingProvider srg;
+	private IMappingProvider bridged;
+
+	public ResourceDownloadUtil() {
+		try {
+			tempDir = Files.createTempDirectory(new File(System.getProperty("java.io.tmpdir")).toPath(), "pw-p-ResourceDownloadUtil-");
+		} catch (IOException ex) {
+			throw new UncheckedIOException("Unable to create temp folder!", ex);
+		}
+	}
+
+	public void createAndRemapMinecraftJar(Path minecraftJar) throws IOException, URISyntaxException {
+		LOGGER.info("Downloading Minecraft jars");
+		Path client = tempDir.resolve("minecraft-client.jar");
+		Path server = tempDir.resolve("minecraft-server.jar");
+		downloadMinecraftJars(client, server);
+		Path obfJar = tempDir.resolve("minecraft-merged.jar");
+
+		try (JarMerger jarMerger = new JarMerger(client.toFile(), server.toFile(), obfJar.toFile())) {
+			jarMerger.enableSyntheticParamsOffset();
+			LOGGER.info("Merging and remapping Minecraft jars");
+			LOGGER.trace(": merging jars");
+			jarMerger.merge();
+		}
+
+		if (srg == null) {
+			// Will cache mappings in memory so when you come along to write them later it skips all that work
+			setupAndLoadMappings(null);
+		}
+
+		LOGGER.trace(": remapping Minecraft jar");
+		Patchwork.remap(this.srg, obfJar, minecraftJar);
+	}
+
+	public void downloadForgeUniversal(Path forgeUniversalJar) throws IOException {
+		FileUtils.copyURLToFile(new URL(FORGE_MAVEN + "/net/minecraftforge/forge/"
+				+ VersionUtil.getForgeVersion() + "/forge-" + VersionUtil.getForgeVersion() + "-universal.jar"), forgeUniversalJar.toFile());
+	}
+
+	public IMappingProvider setupAndLoadMappings(Path voldemapBridged) throws IOException, URISyntaxException {
+		// TODO: use lorenz instead of coderbot's home-grown solution
+		// waiting on https://github.com/CadixDev/Lorenz/pull/38 for this
+		if (this.srg == null) {
+			LOGGER.trace(": downloading mappings");
+
+			Path srg = tempDir.resolve("srg.tsrg");
+			downloadSrg(srg);
+			Path intermediary = tempDir.resolve("intermediary.tsrg");
+			downloadIntermediary(intermediary);
+			IMappingProvider intermediaryProvider = TinyUtils.createTinyMappingProvider(intermediary, "official", "intermediary");
+
+			List<TsrgClass<RawMapping>> classes = Tsrg.readMappings(new FileInputStream(srg.toFile()));
+			TsrgMappings tsrgMappings = new TsrgMappings(classes, intermediaryProvider);
+			this.srg = tsrgMappings;
+			this.bridged = new BridgedMappings(tsrgMappings, intermediaryProvider);
+		}
+
+		if (voldemapBridged != null) {
+			TinyWriter tinyWriter = new TinyWriter("srg", "intermediary");
+			this.bridged.load(tinyWriter);
+			Files.write(voldemapBridged, tinyWriter.toString().getBytes(StandardCharsets.UTF_8));
+		}
+
+		return bridged;
+	}
+
+	private void downloadMinecraftJars(Path client, Path server) throws IOException {
+		Path versionManifest = tempDir.resolve("mc-version-manifest.json");
+		FileUtils.copyURLToFile(new URL("https://launchermeta.mojang.com/mc/game/version_manifest.json"), versionManifest.toFile());
+
+		Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+		JsonArray versions = gson.fromJson(new String(Files.readAllBytes(versionManifest), StandardCharsets.UTF_8), JsonObject.class).get("versions").getAsJsonArray();
+
+		for (JsonElement jsonElement : versions) {
+			if (jsonElement.isJsonObject()) {
+				JsonObject object = jsonElement.getAsJsonObject();
+				String id = object.get("id").getAsJsonPrimitive().getAsString();
+
+				if (id.equals(VersionUtil.getMinecraftVersion())) {
+					String versionUrl = object.get("url").getAsJsonPrimitive().getAsString();
+					JsonObject downloads = gson.fromJson(new InputStreamReader(new URL(versionUrl).openStream()), JsonObject.class)
+							.getAsJsonObject("downloads");
+					String clientJarUrl = downloads.getAsJsonObject("client").get("url").getAsJsonPrimitive().getAsString();
+					String serverJarUrl = downloads.getAsJsonObject("server").get("url").getAsJsonPrimitive().getAsString();
+					LOGGER.trace(": downloading client jar");
+					FileUtils.copyURLToFile(new URL(clientJarUrl), client.toFile());
+					LOGGER.trace(": downloading server jar");
+					FileUtils.copyURLToFile(new URL(serverJarUrl), server.toFile());
+					break;
+				}
+			}
+		}
+	}
+
+	private void downloadSrg(Path mcp) throws IOException, URISyntaxException {
+		LOGGER.trace("      : downloading SRG");
+		Path mcpConfig = tempDir.resolve("mcp-config.zip");
+		FileUtils.copyURLToFile(new URL(FORGE_MAVEN + "/de/oceanlabs/mcp/mcp_config/" + VersionUtil.getMcpConfigVersion()
+				+ "/mcp_config-" + VersionUtil.getMcpConfigVersion() + ".zip"), mcpConfig.toFile());
+		// the jar loader opens zips just fine
+		URI inputJar = new URI("jar:" + mcpConfig.toUri());
+
+		try (FileSystem fs = FileSystems.newFileSystem(inputJar, Collections.emptyMap())) {
+			Files.copy(fs.getPath("/config/joined.tsrg"), mcp);
+		}
+	}
+
+	private void downloadIntermediary(Path intermediary) throws IOException, URISyntaxException {
+		LOGGER.trace("      : downloading Intermediary");
+		Path intJar = tempDir.resolve("intermediary.jar");
+		FileUtils.copyURLToFile(new URL(FABRIC_MAVEN + "/net/fabricmc/intermediary/" + VersionUtil.getMinecraftVersion() + "/intermediary-"
+				+ VersionUtil.getMinecraftVersion() + ".jar"), intJar.toFile());
+
+		URI inputJar = new URI("jar:" + intJar.toUri());
+
+		try (FileSystem fs = FileSystems.newFileSystem(inputJar, Collections.emptyMap())) {
+			Files.copy(fs.getPath("/mappings/mappings.tiny"), intermediary);
+		}
+	}
+
+	private Path createTempDirectory(String name) throws IOException {
+		return Files.createDirectory(tempDir.resolve(name));
+	}
+}

--- a/src/main/java/net/patchworkmc/patcher/util/ResourceDownloader.java
+++ b/src/main/java/net/patchworkmc/patcher/util/ResourceDownloader.java
@@ -37,18 +37,19 @@ import net.patchworkmc.patcher.mapping.Tsrg;
 import net.patchworkmc.patcher.mapping.TsrgClass;
 import net.patchworkmc.patcher.mapping.TsrgMappings;
 
-public class ResourceDownloadUtil {
+public class ResourceDownloader {
 	private static final String FORGE_MAVEN = "https://files.minecraftforge.net/maven";
 	private static final String FABRIC_MAVEN = "https://maven.fabricmc.net";
 	private final Path tempDir;
 
-	private static final Logger LOGGER = LogManager.getLogger(ResourceDownloadUtil.class);
+	private static final Logger LOGGER = LogManager.getLogger(ResourceDownloader.class);
 	private IMappingProvider srg;
 	private IMappingProvider bridged;
 
-	public ResourceDownloadUtil() {
+	public ResourceDownloader() {
 		try {
-			tempDir = Files.createTempDirectory(new File(System.getProperty("java.io.tmpdir")).toPath(), "pw-p-ResourceDownloadUtil-");
+			tempDir = Files.createTempDirectory(new File(System.getProperty("java.io.tmpdir")).toPath(),
+				"patchwork-patcher-ResourceDownloader-");
 		} catch (IOException ex) {
 			throw new UncheckedIOException("Unable to create temp folder!", ex);
 		}
@@ -114,7 +115,8 @@ public class ResourceDownloadUtil {
 		FileUtils.copyURLToFile(new URL("https://launchermeta.mojang.com/mc/game/version_manifest.json"), versionManifest.toFile());
 
 		Gson gson = new GsonBuilder().disableHtmlEscaping().create();
-		JsonArray versions = gson.fromJson(new String(Files.readAllBytes(versionManifest), StandardCharsets.UTF_8), JsonObject.class).get("versions").getAsJsonArray();
+		JsonArray versions = gson.fromJson(new String(Files.readAllBytes(versionManifest), StandardCharsets.UTF_8), JsonObject.class)
+				.get("versions").getAsJsonArray();
 
 		for (JsonElement jsonElement : versions) {
 			if (jsonElement.isJsonObject()) {

--- a/src/main/java/net/patchworkmc/patcher/util/VersionUtil.java
+++ b/src/main/java/net/patchworkmc/patcher/util/VersionUtil.java
@@ -1,0 +1,17 @@
+package net.patchworkmc.patcher.util;
+
+public final class VersionUtil {
+	private VersionUtil() { }
+
+	public static String getMinecraftVersion() {
+		return "1.14.4";
+	}
+
+	public static String getForgeVersion() {
+		return getMinecraftVersion() + "28-2.23";
+	}
+
+	public static String getMcpConfigVersion() {
+		return getMinecraftVersion() + "-20191210.153145";
+	}
+}

--- a/src/main/java/net/patchworkmc/patcher/util/ui/ColorPane.java
+++ b/src/main/java/net/patchworkmc/patcher/util/ui/ColorPane.java
@@ -1,4 +1,4 @@
-package net.patchworkmc.patcher;
+package net.patchworkmc.patcher.util.ui;
 
 import java.awt.Color;
 import java.util.function.Supplier;
@@ -9,6 +9,8 @@ import javax.swing.text.Style;
 import javax.swing.text.StyleConstants;
 
 import org.apache.logging.log4j.Level;
+
+import net.patchworkmc.patcher.PatchworkUI;
 
 public class ColorPane extends JTextPane {
 	private static final Color D_Black = Color.getHSBColor(0.000f, 0.000f, 0.000f);

--- a/src/main/java/net/patchworkmc/patcher/util/ui/UIAppender.java
+++ b/src/main/java/net/patchworkmc/patcher/util/ui/UIAppender.java
@@ -1,4 +1,4 @@
-package net.patchworkmc.patcher;
+package net.patchworkmc.patcher.util.ui;
 
 import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -10,7 +10,7 @@
         </Console>
 
         <!--	Console log in Patchwork/UI	-->
-        <UIAppender name="net.patchworkmc.patcher.UIAppender" maxLines="250">
+        <UIAppender name="net.patchworkmc.patcher.util.ui.UIAppender" maxLines="250">
             <PatternLayout>
                 <LoggerNamePatternSelector defaultPattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}">
                 </LoggerNamePatternSelector>
@@ -21,7 +21,7 @@
     <Loggers>
         <Root level="all">
             <AppenderRef ref="SysOut" level="trace"/>
-            <AppenderRef ref="net.patchworkmc.patcher.UIAppender" level="info"/>
+            <AppenderRef ref="net.patchworkmc.patcher.util.ui.UIAppender" level="info"/>
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
The following changes have been made:
- The command-line entrypoint has been moved to PatchworkCLI.
- VersionUtil was created, which uses methods to provide the current Minecraft
 (and some Forge libraries) versions in order to allow multi-version support
 later.
 - The resource downloading that was in PatchworkUI has been rewritten and
 put in ResourceDownloadUtil.
 - Forge universal downloading has been added, but it's never called.
 The implementation will be done in a separate PR.
 - PatchworkUI and PatchworkCLI now use the same code for downloading
 and loading cached resources via Patchwork.create
- Removes the unused "Ignore sided annotations" option from PatchworkUI
- A merged jar is used instead of a client jar for remapping.
 This commit also removes dev jar generation. There wasn't a good way to
 add support for it with how ResourceDownloadUtil works, and there wasn't a
 good enough reason to hack that in.