### PR TITLE
Use the Intermediary descriptor for ItemGroup#createItem instead of Yarn

### DIFF
--- a/src/main/java/net/patchworkmc/patcher/patch/ItemGroupTransformer.java
+++ b/src/main/java/net/patchworkmc/patcher/patch/ItemGroupTransformer.java
@@ -14,7 +14,7 @@ public class ItemGroupTransformer extends ClassVisitor {
 	private static final String PATCHWORK_ITEM_GROUP = "net/patchworkmc/api/redirects/itemgroup/PatchworkItemGroup";
 
 	private static final String VANILLA_CREATE_ICON = "method_7750";
-	private static final String VANILLA_CREATE_ICON_DESC = "()Lnet/minecraft/item/ItemStack;";
+	private static final String VANILLA_CREATE_ICON_DESC = "()Lnet/minecraft/class_1799;";
 
 	private static final String PATCHWORK_CREATE_ICON = "patchwork$createIcon";
 	private boolean applies;


### PR DESCRIPTION
Replaces "()Lnet/minecraft/item/ItemStack;" with "()Lnet/minecraft/class_1799;".
Tested with MrCrayfish's Furniture Mod.