### PR TITLE
Superclass redirection

### DIFF
--- a/src/main/java/net/patchworkmc/patcher/patch/SuperclassRedirectionTransformer.java
+++ b/src/main/java/net/patchworkmc/patcher/patch/SuperclassRedirectionTransformer.java
@@ -1,0 +1,92 @@
+package net.patchworkmc.patcher.patch;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TypeInsnNode;
+
+import net.patchworkmc.patcher.ForgeModJar;
+import net.patchworkmc.patcher.transformer.NodeBasedMethodAdapter;
+import net.patchworkmc.patcher.transformer.api.ClassPostTransformer;
+import net.patchworkmc.patcher.transformer.api.Transformer;
+import net.patchworkmc.patcher.util.MinecraftVersion;
+
+public class SuperclassRedirectionTransformer extends Transformer {
+	private static final Map<String, Redirection> redirects = new HashMap<>();
+
+	static {
+		// redirects should be added in the form
+		// redirects.put("net/minecraft/intermediary", new Redirection("net/patchworkmc/WrapperClass","(Forge's <init> descriptor)V"))
+	}
+
+	public SuperclassRedirectionTransformer(MinecraftVersion version, ForgeModJar jar, ClassVisitor parent, ClassPostTransformer postTransformer) {
+		super(version, jar, parent, postTransformer);
+	}
+
+	@Override
+	public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+		if (redirects.containsKey(superName)) {
+			superName = redirects.get(superName).name;
+		}
+
+		super.visit(version, access, name, signature, superName, interfaces);
+	}
+
+	@Override
+	public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+		MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+		return new MethodTransformer(access, name, descriptor, signature, exceptions, mv);
+	}
+
+	private static class MethodTransformer extends NodeBasedMethodAdapter {
+		MethodTransformer(int access, String name, String desc, String signature, String[] exceptions, MethodVisitor methodVisitor) {
+			super(access, name, desc, signature, exceptions, methodVisitor);
+		}
+
+		@Override
+		public void transform(MethodNode mn) {
+			for (AbstractInsnNode in : mn.instructions) {
+				if (in instanceof MethodInsnNode) {
+					MethodInsnNode min = (MethodInsnNode) in;
+
+					if (min.getOpcode() == Opcodes.INVOKESPECIAL && min.name.equals("<init>")) {
+						if (redirects.containsKey(min.owner)) {
+							Redirection redirect = redirects.get(min.owner);
+
+							if (min.desc.equals(redirect.initializerDescriptor)) {
+								AbstractInsnNode prev = min;
+
+								while (prev != null) {
+									prev = prev.getPrevious();
+
+									if (prev instanceof TypeInsnNode && prev.getOpcode() == Opcodes.NEW && ((TypeInsnNode) prev).desc.equals(min.owner)) {
+										((TypeInsnNode) prev).desc = redirect.name;
+										break;
+									}
+								}
+
+								min.owner = redirect.name;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private static class Redirection {
+		public final String name;
+		public final String initializerDescriptor;
+
+		Redirection(String name, String initializerDescriptor) {
+			this.name = name;
+			this.initializerDescriptor = initializerDescriptor;
+		}
+	}
+}

--- a/src/main/java/net/patchworkmc/patcher/transformer/NodeBasedMethodAdapter.java
+++ b/src/main/java/net/patchworkmc/patcher/transformer/NodeBasedMethodAdapter.java
@@ -1,0 +1,23 @@
+package net.patchworkmc.patcher.transformer;
+
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.MethodNode;
+
+public abstract class NodeBasedMethodAdapter extends MethodVisitor {
+	MethodVisitor next;
+
+	public NodeBasedMethodAdapter(int access, String name, String desc, String signature, String[] exceptions, MethodVisitor methodVisitor) {
+		super(Opcodes.ASM9, new MethodNode(access, name, desc, signature, exceptions));
+		next = methodVisitor;
+	}
+
+	public abstract void transform(MethodNode mn);
+
+	@Override
+	public void visitEnd() {
+		MethodNode mn = (MethodNode) mv;
+		this.transform(mn);
+		mn.accept(next);
+	}
+}

--- a/src/main/java/net/patchworkmc/patcher/transformer/api/Transformers.java
+++ b/src/main/java/net/patchworkmc/patcher/transformer/api/Transformers.java
@@ -22,6 +22,7 @@ import net.patchworkmc.patcher.patch.ExtensibleEnumTransformer;
 import net.patchworkmc.patcher.patch.ItemGroupTransformer;
 import net.patchworkmc.patcher.patch.KeyBindingsTransformer;
 import net.patchworkmc.patcher.patch.LevelGeneratorTypeTransformer;
+import net.patchworkmc.patcher.patch.SuperclassRedirectionTransformer;
 import net.patchworkmc.patcher.util.MinecraftVersion;
 import net.patchworkmc.patcher.util.VersionRange;
 
@@ -64,6 +65,7 @@ public final class Transformers {
 		addTransformer(ExtensibleEnumTransformer::new);
 		addTransformer(LevelGeneratorTypeTransformer::new);
 		addTransformer(KeyBindingsTransformer::new);
+		addTransformer(SuperclassRedirectionTransformer::new);
 	}
 
 	private static void addTransformer(MinecraftVersion start, MinecraftVersion end, TransformerConstructor constructor) {


### PR DESCRIPTION
This PR adds a transformer to make redirecting the superclass of classes easier.

More specifically it allows us to add a link to the chain of superclasses:

A -> C

to

A -> B -> C

This allows API to easily add and manage the Supplier based transformers that Forge has added to basically everything that can be registry replaced.