### PR TITLE
Remove typetools todo and add a few comments to genInstanceRegistrars

### DIFF
--- a/src/main/java/net/patchworkmc/patcher/event/EventHandlerRewriter.java
+++ b/src/main/java/net/patchworkmc/patcher/event/EventHandlerRewriter.java
@@ -208,7 +208,6 @@ public class EventHandlerRewriter extends VisitorTransformer {
 			instanceRegistrar.visitVarInsn(Opcodes.ALOAD, 0); // Load the target instance (6)
 			// Swap the target instance with a Consumer instance (6)
 			LambdaVisitors.visitConsumerInstanceLambda(instanceRegistrar, callingOpcode, className, subscriber.getMethod(), subscriber.getMethodDescriptor(), isInterface);
-			// TODO: Theoretically we could add a hot path in EventBus that allows us to bypass TypeTools since we know the type from subscriber.getMethodDescriptor
 
 			// Pop the eventbus, params, and the lambda. (0)
 			if (subscriber.getGenericClass().isPresent()) {


### PR DESCRIPTION
Based on my code inspection, the methods that we are calling already hit the non-typetools path, since we're already explicitly specifying the event class. TypeTools is only used for the methods where an explicit event class is not specified, but we do not generate calls to those methods.

I've also added a few comments in the nearby code that hopefully allow it to make a little more sense.