### PR TITLE
Get patcher working on 1.16

### DIFF
--- a/src/main/java/net/patchworkmc/patcher/Patchwork.java
+++ b/src/main/java/net/patchworkmc/patcher/Patchwork.java
@@ -12,7 +12,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -137,16 +136,15 @@ public class Patchwork {
 		return mods;
 	}
 
-	private ForgeModJar parseModManifest(Path jarPath) throws IOException, URISyntaxException, ManifestParseException {
+	private ForgeModJar parseModManifest(Path jarPath) throws IOException, ManifestParseException {
 		String mod = jarPath.getFileName().toString().split("\\.jar")[0];
 		// Load metadata
 		LOGGER.trace("Loading and parsing metadata for %s", mod);
-		URI inputJar = new URI("jar:" + jarPath.toUri());
 
 		FileConfig toml;
 		ForgeAccessTransformer at = null;
 
-		try (FileSystem fs = FileSystems.newFileSystem(inputJar, Collections.emptyMap())) {
+		try (FileSystem fs = FileSystems.newFileSystem(jarPath, getClass().getClassLoader())) {
 			Path manifestPath = fs.getPath("/META-INF/mods.toml");
 			toml = FileConfig.of(manifestPath);
 			toml.load();
@@ -225,8 +223,7 @@ public class Patchwork {
 
 		String json = gson.toJson(primary);
 
-		URI outputJar = new URI("jar:" + output.toUri().toString());
-		FileSystem fs = FileSystems.newFileSystem(outputJar, Collections.emptyMap());
+		FileSystem fs = FileSystems.newFileSystem(output, getClass().getClassLoader());
 		Path fabricModJson = fs.getPath("/fabric.mod.json");
 
 		try {
@@ -270,6 +267,8 @@ public class Patchwork {
 			Path subJarPath = tempDir.resolve(modid + ".jar");
 			Map<String, String> env = new HashMap<>();
 			env.put("create", "true");
+
+			// Need to use a URI here since we need to pass an "env" map
 			FileSystem subFs = FileSystems.newFileSystem(new URI("jar:" + subJarPath.toUri().toString()), env);
 
 			// Write patchwork logo
@@ -365,10 +364,10 @@ public class Patchwork {
 		}
 	}
 
-	public static Patchwork create(Path inputDir, Path outputDir, Path dataDir, MinecraftVersion minecraftVersion) throws IOException, URISyntaxException {
+	public static Patchwork create(Path inputDir, Path outputDir, Path dataDir, MinecraftVersion minecraftVersion) throws IOException {
 		try {
 			return createInner(inputDir, outputDir, dataDir, minecraftVersion);
-		} catch (IOException | URISyntaxException e) {
+		} catch (IOException e) {
 			throw e;
 		} catch (Exception e) {
 			LOGGER.error("Couldn't setup Patchwork!", e);
@@ -377,7 +376,7 @@ public class Patchwork {
 		}
 	}
 
-	private static Patchwork createInner(Path inputDir, Path outputDir, Path dataDir, MinecraftVersion minecraftVersion) throws IOException, URISyntaxException {
+	private static Patchwork createInner(Path inputDir, Path outputDir, Path dataDir, MinecraftVersion minecraftVersion) throws IOException {
 		Files.createDirectories(inputDir);
 		Files.createDirectories(outputDir);
 		Files.createDirectories(dataDir);

--- a/src/main/java/net/patchworkmc/patcher/Patchwork.java
+++ b/src/main/java/net/patchworkmc/patcher/Patchwork.java
@@ -366,6 +366,18 @@ public class Patchwork {
 	}
 
 	public static Patchwork create(Path inputDir, Path outputDir, Path dataDir, MinecraftVersion minecraftVersion) throws IOException, URISyntaxException {
+		try {
+			return createInner(inputDir, outputDir, dataDir, minecraftVersion);
+		} catch (IOException | URISyntaxException e) {
+			throw e;
+		} catch (Exception e) {
+			LOGGER.error("Couldn't setup Patchwork!", e);
+
+			throw new RuntimeException("Couldn't setup Patchwork!", e);
+		}
+	}
+
+	private static Patchwork createInner(Path inputDir, Path outputDir, Path dataDir, MinecraftVersion minecraftVersion) throws IOException, URISyntaxException {
 		Files.createDirectories(inputDir);
 		Files.createDirectories(outputDir);
 		Files.createDirectories(dataDir);

--- a/src/main/java/net/patchworkmc/patcher/Patchwork.java
+++ b/src/main/java/net/patchworkmc/patcher/Patchwork.java
@@ -423,13 +423,13 @@ public class Patchwork {
 				LOGGER.warn("Mappings not cached, downloading!");
 			}
 
-			bridgedMappings = downloader.setupAndLoadMappings(mappings);
+			bridgedMappings = downloader.setupAndLoadMappings(mappings, minecraftJar);
 
 			if (!mappingsCached) {
 				LOGGER.warn("Done");
 			}
 		} else if (mappingsCached) {
-			bridgedMappings = downloader.setupAndLoadMappings(null);
+			bridgedMappings = downloader.setupAndLoadMappings(null, minecraftJar);
 		} else {
 			bridgedMappings = TinyUtils.createTinyMappingProvider(mappings, "srg", "intermediary");
 		}

--- a/src/main/java/net/patchworkmc/patcher/PatchworkUI.java
+++ b/src/main/java/net/patchworkmc/patcher/PatchworkUI.java
@@ -8,7 +8,6 @@ import java.awt.Toolkit;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.security.Permission;
 import java.util.Arrays;
@@ -320,7 +319,7 @@ public class PatchworkUI {
 		LOGGER.info("Cleared cache.");
 	}
 
-	private static void startPatching() throws IOException, URISyntaxException {
+	private static void startPatching() throws IOException {
 		Path current = root.toPath();
 		// find the selected minecraft version
 		MinecraftVersion version = MinecraftVersion.valueOf("V" + ((String) versions.getSelectedItem()).replace('.', '_'));

--- a/src/main/java/net/patchworkmc/patcher/mapping/TsrgMappings.java
+++ b/src/main/java/net/patchworkmc/patcher/mapping/TsrgMappings.java
@@ -23,7 +23,7 @@ public class TsrgMappings implements IMappingProvider {
 			Map<String, String> fieldToDescription = fieldDescriptions.get(unpaired.getOfficial());
 
 			if (fieldToDescription == null && unpaired.getFields().size() != 0) {
-				throw new IllegalArgumentException("Provided field descriptions is missing descriptions for the class " + unpaired.getOfficial() + "(MCP Name: " + unpaired.getMapped() + ")");
+				throw new IllegalArgumentException("Provided field descriptions is missing descriptions for the class " + unpaired.getOfficial() + " (MCP Name: " + unpaired.getMapped() + ")");
 			}
 
 			for (RawMapping field : unpaired.getFields()) {

--- a/src/main/java/net/patchworkmc/patcher/util/MinecraftVersion.java
+++ b/src/main/java/net/patchworkmc/patcher/util/MinecraftVersion.java
@@ -1,7 +1,8 @@
 package net.patchworkmc.patcher.util;
 
 public enum MinecraftVersion {
-	V1_14_4("1.14.4");
+	V1_14_4("1.14.4"),
+	V1_16_4("1.16.4");
 
 	private final String version;
 

--- a/src/main/java/net/patchworkmc/patcher/util/ResourceDownloader.java
+++ b/src/main/java/net/patchworkmc/patcher/util/ResourceDownloader.java
@@ -94,7 +94,7 @@ public final class ResourceDownloader {
 
 			Path srg = tempDir.resolve("srg.tsrg");
 			downloadSrg(srg);
-			Path intermediary = tempDir.resolve("intermediary.tsrg");
+			Path intermediary = tempDir.resolve("intermediary.tiny");
 			downloadIntermediary(intermediary);
 			IMappingProvider intermediaryProvider = TinyUtils.createTinyMappingProvider(intermediary, "official", "intermediary");
 

--- a/src/main/java/net/patchworkmc/patcher/util/ResourceDownloader.java
+++ b/src/main/java/net/patchworkmc/patcher/util/ResourceDownloader.java
@@ -14,6 +14,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 import com.google.gson.Gson;
@@ -74,7 +75,7 @@ public final class ResourceDownloader {
 
 		if (srg == null) {
 			// Will cache mappings in memory so when you come along to write them later it skips all that work
-			setupAndLoadMappings(null);
+			setupAndLoadMappings(null, obfJar);
 		}
 
 		LOGGER.trace(": remapping Minecraft jar");
@@ -86,7 +87,7 @@ public final class ResourceDownloader {
 				+ "/forge-" + forgeVersion + "-universal.jar"), forgeUniversalJar.toFile());
 	}
 
-	public IMappingProvider setupAndLoadMappings(Path voldemapBridged) throws IOException, URISyntaxException {
+	public IMappingProvider setupAndLoadMappings(Path voldemapBridged, Path mergedMinecraftJar) throws IOException, URISyntaxException {
 		// TODO: use lorenz instead of coderbot's home-grown solution
 		// waiting on https://github.com/CadixDev/Lorenz/pull/38 for this
 		if (this.srg == null) {
@@ -99,6 +100,9 @@ public final class ResourceDownloader {
 			IMappingProvider intermediaryProvider = TinyUtils.createTinyMappingProvider(intermediary, "official", "intermediary");
 
 			List<TsrgClass<RawMapping>> classes = Tsrg.readMappings(new FileInputStream(srg.toFile()));
+
+			purgeNonexistentClassMappings(classes, mergedMinecraftJar);
+
 			TsrgMappings tsrgMappings = new TsrgMappings(classes, intermediaryProvider);
 			this.srg = tsrgMappings;
 			this.bridged = new BridgedMappings(tsrgMappings, intermediaryProvider);
@@ -111,6 +115,54 @@ public final class ResourceDownloader {
 		}
 
 		return bridged;
+	}
+
+	/**
+	 * Purges SRG mappings for classes that don't actually exist in the merged Minecraft jar
+	 *
+	 * <p>Newer versions of MCPConfig include mappings for classes (currently, "afg" and "dew" in 1.16.4) that do not
+	 * exist in either the Minecraft client or server jars for 1.16.4. It's unclear why exactly these mappings are
+	 * present, but interestingly enough, they are also present in the 1.16.4 Mojang mappings (client.txt / server.txt).
+	 * It seems likely that whatever automated tools the MCPConfig/Forge team use to update their mappings get confused
+	 * by this and retain the orphaned mappings.</p>
+	 *
+	 * <p>Unfortunately, some of our code doesn't particularly like these missing mappings. The code that combines the
+	 * SRG mappings (official->srg) and intermediary mappings (official->intermediary) into bridged mappings
+	 * (srg->intermediary) in particular has issues when it tries to locate the orphaned mappings within intermediary,
+	 * since intermediary doesn't contain the orphaned mappings. Therefore, we remove the orphaned mappings by checking
+	 * whether each given class actually exists in the Minecraft jar, so that they don't cause any problems.</p>
+	 */
+	private void purgeNonexistentClassMappings(List<TsrgClass<RawMapping>> classes, Path mergedMinecraftJar) throws URISyntaxException, IOException {
+		// I'm using an iterator here since it allows us to remove entries easily as we iterate over the List
+		Iterator<TsrgClass<RawMapping>> classIterator = classes.iterator();
+
+		URI jarUri = new URI("jar:" + mergedMinecraftJar.toUri());
+
+		boolean needsClarificationMessage = false;
+
+		try (FileSystem fs = FileSystems.newFileSystem(jarUri, Collections.emptyMap())) {
+			while (classIterator.hasNext()) {
+				TsrgClass<RawMapping> clazz = classIterator.next();
+
+				String officialName = clazz.getOfficial();
+				Path path = fs.getPath("/" + officialName + ".class");
+
+				if (!Files.exists(path)) {
+					LOGGER.warn("The class " + clazz.getOfficial() + " (MCP Name: " + clazz.getMapped() + ") has an SRG mapping but is not actually present in the merged Minecraft jar!");
+					needsClarificationMessage = true;
+
+					classIterator.remove();
+				}
+			}
+		}
+
+		if (needsClarificationMessage) {
+			// I print the above warnings so that they can be cross-checked if necessary for debugging, however I don't
+			// want someone just casually reading the log to be concerned since they're nominal otherwise.
+			//
+			// Therefore, print a single message stating that the warnings are nominal.
+			LOGGER.warn("Please note that the above warnings are expected on newer versions of Minecraft (such as 1.16.4)");
+		}
 	}
 
 	private void downloadMinecraftJars(Path client, Path server) throws IOException {


### PR DESCRIPTION
Things mostly seem to work, but obviously I can't actually test the patched mods yet. This was surprisingly easy, thanks to all of the work done ahead of time to prepare by Glitch.

For those watching: Please note that this doesn't actually let you use Patchwork as a whole on 1.16, since Patchwork API (a critical component) is still only available for 1.14.4. It will need to be ported to 1.16 as well first!