### PR TITLE
Fixes for access transformer parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 	implementation 'org.ow2.asm:asm-util:9.0'
 
 	// Patchwork
-	implementation 'net.patchworkmc:patchwork-manifest:0.5.0'
+	implementation 'net.patchworkmc:patchwork-manifest:0.6.1'
 
 	// Logging
 	implementation 'org.apache.logging.log4j:log4j-api:2.13.2'

--- a/src/main/java/net/patchworkmc/patcher/Patchwork.java
+++ b/src/main/java/net/patchworkmc/patcher/Patchwork.java
@@ -167,7 +167,7 @@ public class Patchwork {
 		}
 
 		if (at != null) {
-			at.remap(accessTransformerRemapper, ex -> LOGGER.throwing(Level.WARN, ex));
+			at.remap(accessTransformerRemapper, ex -> LOGGER.log(Level.WARN, "Error remapping the access transformer for %s: %s", mod, ex.getMessage()));
 		}
 
 		return new ForgeModJar(jarPath, outputDir.resolve(jarPath.getFileName()), manifest, at);

--- a/src/main/java/net/patchworkmc/patcher/manifest/converter/accesstransformer/AccessTransformerConverter.java
+++ b/src/main/java/net/patchworkmc/patcher/manifest/converter/accesstransformer/AccessTransformerConverter.java
@@ -38,14 +38,14 @@ public class AccessTransformerConverter {
 			try {
 				writeWildcards(sb, targetClass.getName(), targetClass.getFieldWildcard(), targetClass.getMethodWildcard(), info);
 			} catch (MissingMappingException ex) {
-				Patchwork.LOGGER.throwing(Level.WARN, ex);
+				Patchwork.LOGGER.log(Level.WARN, "Couldn't write wildcards for class %s: %s", targetClass.getName(), ex.getMessage());
 			}
 
 			for (TransformedField field : targetClass.getFields()) {
 				try {
 					writeField(sb, field, info);
 				} catch (MissingMappingException ex) {
-					Patchwork.LOGGER.throwing(Level.WARN, ex);
+					Patchwork.LOGGER.log(Level.WARN, "Couldn't convert field %s in class %s: %s", field.getName(), field.getOwner(), ex.getMessage());
 				}
 			}
 


### PR DESCRIPTION
A lot of access transformers have issues that Forge ignores. Patchwork warns about these, and the warnings can get a bit spammy... I've tried to make it so that we don't generate megabytes of access transformer errors on large modpacks.

Also, I've upgraded Patchwork Manifest to 0.6.1 to fix a few issues.