### PR TITLE
Use the correct mod ID for child mods

### DIFF
--- a/src/main/java/net/patchworkmc/patcher/Patchwork.java
+++ b/src/main/java/net/patchworkmc/patcher/Patchwork.java
@@ -266,8 +266,10 @@ public class Patchwork {
 				continue;
 			}
 
+			String subModId = entry.get("id").getAsString();
+
 			// generate the jar
-			Path subJarPath = tempDir.resolve(modid + ".jar");
+			Path subJarPath = tempDir.resolve(subModId + ".jar");
 			Map<String, String> env = new HashMap<>();
 			env.put("create", "true");
 			FileSystem subFs = FileSystems.newFileSystem(new URI("jar:" + subJarPath.toUri().toString()), env);
@@ -281,7 +283,7 @@ public class Patchwork {
 
 			subFs.close();
 
-			Files.write(fs.getPath("/META-INF/jars/" + modid + ".jar"), Files.readAllBytes(subJarPath));
+			Files.write(fs.getPath("/META-INF/jars/" + subModId + ".jar"), Files.readAllBytes(subJarPath));
 
 			Files.delete(subJarPath);
 		}


### PR DESCRIPTION
Before, child mod jars were all generated with the parent mod id, causing only one jar to be in the final patched file. This change generates the jars with each child mod's mod ID.