### PR TITLE
Fix bad default logic in StaticMethodRedirector

### DIFF
--- a/src/main/java/net/patchworkmc/patcher/patch/redirect/StaticMethodRedirector.java
+++ b/src/main/java/net/patchworkmc/patcher/patch/redirect/StaticMethodRedirector.java
@@ -50,7 +50,7 @@ public class StaticMethodRedirector extends NodeTransformer {
 
 			String newMethodName = classRedirection.mapEntries.get(insn.name + insn.desc);
 
-			if (newMethodName != null) {
+			if (newMethodName == null) {
 				newMethodName = insn.name;
 			}
 


### PR DESCRIPTION
The current implementation of StaticMethodRedirector replaced the name with the default if there was a mapping found for the name, rather than the opposite. This lead to a crash when patching any mod that uses something it redirects, the most obvious case being Class.forName, breaking most large mods that use reflection.